### PR TITLE
partitions & flashlayout: Prevent accident substring match

### DIFF
--- a/classes/flashlayout-stm32mp.bbclass
+++ b/classes/flashlayout-stm32mp.bbclass
@@ -135,7 +135,7 @@ python __anonymous () {
                 # Init partition list from PARTITIONS_IMAGE
                 image_partitions = (d.getVar('PARTITIONS_IMAGE') or "").split()
                 # We need to clearly identify ROOTFS build, not InitRAMFS one (if any)
-                if current_image_name not in image_partitions and current_image_name not in initramfs and current_image_name not in initrd:
+                if current_image_name not in image_partitions and current_image_name != initramfs and current_image_name != initrd:
                     # We need to make sure to add all extra dependencies as 'depends'
                     # for image_complete task
                     if d.getVar('FLASHLAYOUT_DEPEND_TASKS'):

--- a/classes/st-partitions-image.bbclass
+++ b/classes/st-partitions-image.bbclass
@@ -32,7 +32,7 @@ python __anonymous () {
                 # We need to append partition images generation only to image
                 # that are not one of the defined partitions and not the InitRAMFS image.
                 # Without this check we would create circular dependency
-                if current_image_name not in image_partitions and current_image_name not in initramfs:
+                if current_image_name not in image_partitions and current_image_name != initramfs:
                     for partition in image_partitions:
                         d.appendVarFlag('do_image_complete', 'depends', ' %s:do_image_complete' % partition)
 }


### PR DESCRIPTION
There is a case that I bitbake `my-image` when INITRAMFS_IMAGE is `my-image-initramfs`. In this case `my-image` is a substring of `my-image-initramfs`, causing ST's flashlayout and partitions classes accidentally skip adding their tasks.

This patch makes sure to use exact string match during variable checks.