### PR TITLE
Fix WIC image generation

### DIFF
--- a/conf/machine/stm32mp1-disco.conf
+++ b/conf/machine/stm32mp1-disco.conf
@@ -92,6 +92,6 @@ WKS_FILE_DEPENDS ?= " \
     st-image-vendorfs \
     st-image-userfs \
 "
-# for generated a WIC file, please uncomment the 2 following lines
-#IMAGE_FSTYPES += "wic"
+# for generated a WIC file, please uncomment the 2 following lines  or add them to local.conf
+#IMAGE_FSTYPES += "wic ext4"
 #WKS_FILE += "${@bb.utils.contains('BOOTSCHEME_LABELS', 'optee', 'sdcard-stm32mp157c-dk2-optee-1GB.wks', 'sdcard-stm32mp157c-dk2-trusted-1GB.wks', d)}"

--- a/conf/machine/stm32mp1-disco.conf
+++ b/conf/machine/stm32mp1-disco.conf
@@ -94,4 +94,4 @@ WKS_FILE_DEPENDS ?= " \
 "
 # for generated a WIC file, please uncomment the 2 following lines  or add them to local.conf
 #IMAGE_FSTYPES += "wic ext4"
-#WKS_FILE += "${@bb.utils.contains('BOOTSCHEME_LABELS', 'optee', 'sdcard-stm32mp157c-dk2-optee-1GB.wks', 'sdcard-stm32mp157c-dk2-trusted-1GB.wks', d)}"
+#WKS_FILE += "${@bb.utils.contains('BOOTSCHEME_LABELS', 'optee', 'sdcard-stm32mp157c-dk2-optee-1GB.wks.in', 'sdcard-stm32mp157c-dk2-trusted-1GB.wks.in', d)}"

--- a/wic/sdcard-stm32mp157c-dk2-optee-1GB.wks.in
+++ b/wic/sdcard-stm32mp157c-dk2-optee-1GB.wks.in
@@ -19,9 +19,9 @@ part teeh  --source gptcopy --sourceparams="file=tee-header_v2-stm32mp157c-dk2-o
 part teed  --source gptcopy --sourceparams="file=tee-pageable_v2-stm32mp157c-dk2-optee.stm32" --ondisk mmcblk --label ssbl --part-type 0x8301 --fixed-size 256K
 part teex  --source gptcopy --sourceparams="file=tee-pager_v2-stm32mp157c-dk2-optee.stm32" --ondisk mmcblk --label ssbl --part-type 0x8301 --fixed-size 256K
 
-part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-openstlinux-weston-stm32mp1.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M
-part vendorfs --source rawcopy --sourceparams="file=st-image-vendorfs-openstlinux-weston-stm32mp1.ext4" --ondisk mmcblk --fstype=ext4 --label vendorfs --active --fixed-size 16M
+part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M
+part vendorfs --source rawcopy --sourceparams="file=st-image-vendorfs-${DISTRO}-${MACHINE}.ext4" --ondisk mmcblk --fstype=ext4 --label vendorfs --active --fixed-size 16M
 part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size 768M
-part usrfs --source rawcopy --sourceparams="file=st-image-userfs-openstlinux-weston-stm32mp1.ext4" --ondisk mmcblk --fstype=ext4 --label userfs --active --fixed-size 172M
+part usrfs --source rawcopy --sourceparams="file=st-image-userfs-${DISTRO}-${MACHINE}.ext4" --ondisk mmcblk --fstype=ext4 --label userfs --active --fixed-size 172M
 
 bootloader --ptable gpt

--- a/wic/sdcard-stm32mp157c-dk2-trusted-1GB.wks.in
+++ b/wic/sdcard-stm32mp157c-dk2-trusted-1GB.wks.in
@@ -15,9 +15,9 @@ part fsbl1 --source gptcopy --sourceparams="file=tf-a-stm32mp157c-dk2-trusted.st
 part fsbl2 --source gptcopy --sourceparams="file=tf-a-stm32mp157c-dk2-trusted.stm32" --ondisk mmcblk --label fsbl2 --part-type 0x8301 --fixed-size 256K
 part ssbl  --source gptcopy --sourceparams="file=u-boot-stm32mp157c-dk2-trusted.stm32" --ondisk mmcblk --label ssbl --part-type 0x8301 --fixed-size 2048K
 
-part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-openstlinux-weston-stm32mp1.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M
-part vendorfs --source rawcopy --sourceparams="file=st-image-vendorfs-openstlinux-weston-stm32mp1.ext4" --ondisk mmcblk --fstype=ext4 --label vendorfs --active --fixed-size 16M
+part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M
+part vendorfs --source rawcopy --sourceparams="file=st-image-vendorfs-${DISTRO}-${MACHINE}.ext4" --ondisk mmcblk --fstype=ext4 --label vendorfs --active --fixed-size 16M
 part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size 768M
-part usrfs --source rawcopy --sourceparams="file=st-image-userfs-openstlinux-weston-stm32mp1.ext4" --ondisk mmcblk --fstype=ext4 --label userfs --active --fixed-size 173M
+part usrfs --source rawcopy --sourceparams="file=st-image-userfs-${DISTRO}-${MACHINE}.ext4" --ondisk mmcblk --fstype=ext4 --label userfs --active --fixed-size 173M
 
 bootloader --ptable gpt


### PR DESCRIPTION
Hi,

The commits in this GitHub PR fix the example for generation WIC file in conf/machine/stm32mp1-disco.conf with the following modifications:
*  Enable ext4 generation for bootfs, userfs and vendorfs
*  Use wks.in templates rathen then static wks
*  Use variables instead of hardcoded values like openstlinux-weston and stm32mp1

Best regards, Leon