### PR TITLE
Make sure disabling ST's flashlayout & partitions work as expected

### DIFF
--- a/classes/flashlayout-stm32mp.bbclass
+++ b/classes/flashlayout-stm32mp.bbclass
@@ -120,7 +120,7 @@ FLASHLAYOUT_CONFIGURE_FILES ??= ""
 # -----------------------------------------------------------------------------
 python __anonymous () {
     flashlayout_config = d.getVar('ENABLE_FLASHLAYOUT_CONFIG')
-    if flashlayout_config:
+    if flashlayout_config == "1":
         # Gather all current tasks
         tasks = filter(lambda k: d.getVarFlag(k, "task", True), d.keys())
         for task in tasks:

--- a/classes/st-partitions-image.bbclass
+++ b/classes/st-partitions-image.bbclass
@@ -38,6 +38,10 @@ python __anonymous () {
 }
 
 image_rootfs_image_clean_task () {
+    if [ ${ENABLE_PARTITIONS_IMAGE} -ne "1" ]; then
+        return
+    fi
+
     for name in ${PARTITIONS_IMAGE};
     do
         if `echo ${IMAGE_NAME} | grep -q $name` ;


### PR DESCRIPTION
The current ST's .bbclass files do not really checks if
ENABLE_PARTITIONS_IMAGE and ENABLE_FLASHLAYOUT_CONFIG are unset.
This silently breaks third-party distributions that use
their own partitions layout and root directory structures.

Signed-off-by: Bumsik Kim <k.bumsik@gmail.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/stmicroelectronics/meta-st-stm32mp/9)
<!-- Reviewable:end -->
