### PR TITLE
Uboot fixes

### DIFF
--- a/conf/machine/include/st-machine-common-stm32mp.inc
+++ b/conf/machine/include/st-machine-common-stm32mp.inc
@@ -281,6 +281,7 @@ LINUX_A7_EXAMPLES_DT ?= ""
 # u-boot
 # =========================================================================
 EXTRA_IMAGEDEPENDS += "u-boot-stm32mp"
+PREFERRED_PROVIDER_u-boot = "u-boot-stm32mp"
 PREFERRED_PROVIDER_virtual/bootloader = "u-boot-stm32mp"
 
 # Define default U-Boot config

--- a/recipes-bsp/u-boot/u-boot-stm32mp_2018.11.bb
+++ b/recipes-bsp/u-boot/u-boot-stm32mp_2018.11.bb
@@ -8,3 +8,6 @@ LICENSE = "GPLv2+"
 # Configure archiver use
 # ---------------------------------
 include ${@oe.utils.ifelse(d.getVar('ST_ARCHIVER_ENABLE') == '1', 'u-boot-stm32mp-archiver.inc','')}
+
+PROVIDES += "u-boot"
+RPROVIDES_${PN} += "u-boot"


### PR DESCRIPTION
It is a valid use-case for a recipe or layer to have a dependency on `u-boot` and currently it is not possible to use the meta-st-stm32mp layer in such situations and the commits in this PR is an attempt to remedy this.

This is applicable to `thud`, `warrior` and `zeus` branches.