### PR TITLE
Feature/support wic dynamic machines

### DIFF
--- a/wic/sdcard-stm32mp157c-dk2-optee-1GB.wks.in
+++ b/wic/sdcard-stm32mp157c-dk2-optee-1GB.wks.in
@@ -19,9 +19,9 @@ part teeh  --source gptcopy --sourceparams="file=tee-header_v2-stm32mp157c-dk2-o
 part teed  --source gptcopy --sourceparams="file=tee-pageable_v2-stm32mp157c-dk2-optee.stm32" --ondisk mmcblk --label ssbl --part-type 0x8301 --fixed-size 256K
 part teex  --source gptcopy --sourceparams="file=tee-pager_v2-stm32mp157c-dk2-optee.stm32" --ondisk mmcblk --label ssbl --part-type 0x8301 --fixed-size 256K
 
-part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-openstlinux-weston-stm32mp1.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M
-part vendorfs --source rawcopy --sourceparams="file=st-image-vendorfs-openstlinux-weston-stm32mp1.ext4" --ondisk mmcblk --fstype=ext4 --label vendorfs --active --fixed-size 16M
+part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-openstlinux-weston-${MACHINE}.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M
+part vendorfs --source rawcopy --sourceparams="file=st-image-vendorfs-openstlinux-weston-${MACHINE}.ext4" --ondisk mmcblk --fstype=ext4 --label vendorfs --active --fixed-size 16M
 part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size 768M
-part usrfs --source rawcopy --sourceparams="file=st-image-userfs-openstlinux-weston-stm32mp1.ext4" --ondisk mmcblk --fstype=ext4 --label userfs --active --fixed-size 172M
+part usrfs --source rawcopy --sourceparams="file=st-image-userfs-openstlinux-weston-${MACHINE}.ext4" --ondisk mmcblk --fstype=ext4 --label userfs --active --fixed-size 172M
 
 bootloader --ptable gpt

--- a/wic/sdcard-stm32mp157c-dk2-trusted-1GB.wks.in
+++ b/wic/sdcard-stm32mp157c-dk2-trusted-1GB.wks.in
@@ -15,9 +15,9 @@ part fsbl1 --source gptcopy --sourceparams="file=tf-a-stm32mp157c-dk2-trusted.st
 part fsbl2 --source gptcopy --sourceparams="file=tf-a-stm32mp157c-dk2-trusted.stm32" --ondisk mmcblk --label fsbl2 --part-type 0x8301 --fixed-size 256K
 part ssbl  --source gptcopy --sourceparams="file=u-boot-stm32mp157c-dk2-trusted.stm32" --ondisk mmcblk --label ssbl --part-type 0x8301 --fixed-size 2048K
 
-part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-openstlinux-weston-stm32mp1.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M
-part vendorfs --source rawcopy --sourceparams="file=st-image-vendorfs-openstlinux-weston-stm32mp1.ext4" --ondisk mmcblk --fstype=ext4 --label vendorfs --active --fixed-size 16M
+part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-openstlinux-weston-${MACHINE}.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M
+part vendorfs --source rawcopy --sourceparams="file=st-image-vendorfs-openstlinux-weston-${MACHINE}.ext4" --ondisk mmcblk --fstype=ext4 --label vendorfs --active --fixed-size 16M
 part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size 768M
-part usrfs --source rawcopy --sourceparams="file=st-image-userfs-openstlinux-weston-stm32mp1.ext4" --ondisk mmcblk --fstype=ext4 --label userfs --active --fixed-size 173M
+part usrfs --source rawcopy --sourceparams="file=st-image-userfs-openstlinux-weston-${MACHINE}.ext4" --ondisk mmcblk --fstype=ext4 --label userfs --active --fixed-size 173M
 
 bootloader --ptable gpt

--- a/wic/sdcard-stm32mp157c-ev1-optee-1GB.wks.in
+++ b/wic/sdcard-stm32mp157c-ev1-optee-1GB.wks.in
@@ -19,9 +19,9 @@ part teeh  --source gptcopy --sourceparams="file=tee-header_v2-stm32mp157c-ev1-o
 part teed  --source gptcopy --sourceparams="file=tee-pageable_v2-stm32mp157c-ev1-optee.stm32" --ondisk mmcblk --label ssbl --part-type 0x8301 --fixed-size 256K
 part teex  --source gptcopy --sourceparams="file=tee-pager_v2-stm32mp157c-ev1-optee.stm32" --ondisk mmcblk --label ssbl --part-type 0x8301 --fixed-size 256K
 
-part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-openstlinux-weston-stm32mp1.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M
-part vendorfs --source rawcopy --sourceparams="file=st-image-vendorfs-openstlinux-weston-stm32mp1.ext4" --ondisk mmcblk --fstype=ext4 --label vendorfs --active --fixed-size 16M
+part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-openstlinux-weston-${MACHINE}.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M
+part vendorfs --source rawcopy --sourceparams="file=st-image-vendorfs-openstlinux-weston-${MACHINE}.ext4" --ondisk mmcblk --fstype=ext4 --label vendorfs --active --fixed-size 16M
 part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size 768M
-part usrfs --source rawcopy --sourceparams="file=st-image-userfs-openstlinux-weston-stm32mp1.ext4" --ondisk mmcblk --fstype=ext4 --label userfs --active --fixed-size 172M
+part usrfs --source rawcopy --sourceparams="file=st-image-userfs-openstlinux-weston-${MACHINE}.ext4" --ondisk mmcblk --fstype=ext4 --label userfs --active --fixed-size 172M
 
 bootloader --ptable gpt

--- a/wic/sdcard-stm32mp157c-ev1-trusted-1GB.wks.in
+++ b/wic/sdcard-stm32mp157c-ev1-trusted-1GB.wks.in
@@ -15,9 +15,9 @@ part fsbl1 --source gptcopy --sourceparams="file=tf-a-stm32mp157c-ev1-trusted.st
 part fsbl2 --source gptcopy --sourceparams="file=tf-a-stm32mp157c-ev1-trusted.stm32" --ondisk mmcblk --label fsbl2 --part-type 0x8301 --fixed-size 256K
 part ssbl  --source gptcopy --sourceparams="file=u-boot-stm32mp157c-ev1-trusted.stm32" --ondisk mmcblk --label ssbl --part-type 0x8301 --fixed-size 2048K
 
-part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-openstlinux-weston-stm32mp1.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M
-part vendorfs --source rawcopy --sourceparams="file=st-image-vendorfs-openstlinux-weston-stm32mp1.ext4" --ondisk mmcblk --fstype=ext4 --label vendorfs --active --fixed-size 16M
+part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-openstlinux-weston-${MACHINE}.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M
+part vendorfs --source rawcopy --sourceparams="file=st-image-vendorfs-openstlinux-weston-${MACHINE}.ext4" --ondisk mmcblk --fstype=ext4 --label vendorfs --active --fixed-size 16M
 part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size 768M
-part usrfs --source rawcopy --sourceparams="file=st-image-userfs-openstlinux-weston-stm32mp1.ext4" --ondisk mmcblk --fstype=ext4 --label userfs --active --fixed-size 173M
+part usrfs --source rawcopy --sourceparams="file=st-image-userfs-openstlinux-weston-${MACHINE}.ext4" --ondisk mmcblk --fstype=ext4 --label userfs --active --fixed-size 173M
 
 bootloader --ptable gpt


### PR DESCRIPTION
Bitbake has an un-documented features, which is that wic parser can do post-processing on wic files when the file extension is `wic.in`.

Currently, all wks files in `wic/` folder have constant definitions, therefore wic fails when bitbake has build a rootfs for any MACHINE other that `stm32mp1`, which means that devs needs to either modify the wks in this meta-layer or point to another wks file. Both need modification in this layer or create an override meta layer, which is time consuming.

#### To reproduce the problem:
- Uncomment these two lines in `conf/machine/stm32mp1-disco.conf`
```
#IMAGE_FSTYPES += "wic"
#WKS_FILE += "${@bb.utils.contains('BOOTSCHEME_LABELS', 'optee', 'sdcard-stm32mp157c-dk2-optee-1GB.wks', 'sdcard-stm32mp157c-dk2-trusted-1GB.wks', d)}"
```
- Build an image using `MACHINE=stm32mp1-disco`

The above will fail as it will try to find this rootfs: `st-image-userfs-openstlinux-weston-stm32mp1.ext4`

#### Solution & verification
This commit uses `*.wic.in` feature, which is supported in `thud` (and greater versions) and replaces `stm32mp1` with `${MACHINE}` in all rootfs in sourceparams in wks files.

To verify that it works then repeat the steps above that reproduce the problem.
