### PR TITLE
Added removal for the most used wic types from custom images

### DIFF
--- a/recipes-st/images/st-image-bootfs.bb
+++ b/recipes-st/images/st-image-bootfs.bb
@@ -3,7 +3,7 @@ LICENSE = "MIT"
 
 inherit core-image
 
-IMAGE_FSTYPES_remove = "wic"
+IMAGE_FSTYPES_remove = "wic wic.bz2 wic.bmap"
 
 IMAGE_NAME_SUFFIX = ".${STM32MP_BOOTFS_LABEL}fs"
 

--- a/recipes-st/images/st-image-userfs.bb
+++ b/recipes-st/images/st-image-userfs.bb
@@ -3,7 +3,7 @@ LICENSE = "MIT"
 
 inherit core-image
 
-IMAGE_FSTYPES_remove = "wic"
+IMAGE_FSTYPES_remove = "wic wic.bz2 wic.bmap"
 
 IMAGE_NAME_SUFFIX = ".${STM32MP_USERFS_LABEL}"
 

--- a/recipes-st/images/st-image-vendorfs.bb
+++ b/recipes-st/images/st-image-vendorfs.bb
@@ -3,7 +3,7 @@ LICENSE = "MIT"
 
 inherit core-image
 
-IMAGE_FSTYPES_remove = "wic"
+IMAGE_FSTYPES_remove = "wic wic.bz2 wic.bmap"
 
 IMAGE_NAME_SUFFIX = ".${STM32MP_VENDORFS_LABEL}"
 


### PR DESCRIPTION
Signed-off-by: Dimitris Tassopoulos <dimtass@gmail.com>

Usually wic image fstype is not used as a standalone type since it doesn't provide any flashing acceleration without the map file (bmap). Also, usually in production environments .wic.bz2 images are most common because of their small size, which makes them easier and more efficient to store and distribute.

The problem with `recipes-st/images/st-image-bootfs.bb`, `recipes-st/images/st-image-userfs.bb` and `recipes-st/images/st-image-vendorfs.bb` is that they only remove the `wic` FSTYPE, therefore if you add `wic.bz2` and `wic.bmap` in `conf/machine/stm32mp1-eval.conf` then the build fails as all images inherit the `core-image`.

#### Re-produce
To re-produce the error add this to `meta-st-stm32mp/conf/machine/stm32mp1-disco.conf`
```
IMAGE_FSTYPES += "wic wic.bz2 wic.bmap"
```

(Usually this is added by other meta-layers that are using this MACHINE).

To fix the issue the most commong wic extensions need to be added in the previous images:

```
IMAGE_FSTYPES_remove = "wic wic.bz2 wic.bmap"
```

#### Follow-up
Adding `IMAGE_FSTYPES += "wic wic.bz2 wic.bmap"` in `meta-st-stm32mp/conf/machine/stm32mp1-disco.conf` and `meta-st-stm32mp/conf/machine/stm32mp1-eval.conf` is also recommended. If agreed I can add this to this PR.