### PR TITLE
GDB: fix sdk build error

### DIFF
--- a/recipes-devtools/gdb/gdb-cross-canadian_%.bbappend
+++ b/recipes-devtools/gdb/gdb-cross-canadian_%.bbappend
@@ -14,6 +14,6 @@ EXTRA_OECONF_append_stm32mpcommon = " \
 
 do_install_append_stm32mpcommon() {
    install -d ${D}/${bindir}/
-   cp -a ${WORKDIR}/gdbinit ${D}/${bindir}/
+   cp -a --no-preserve=ownership ${WORKDIR}/gdbinit ${D}/${bindir}/
 }
 


### PR DESCRIPTION
     0546:                if include_owners:
     0547:                    try:
 *** 0548:                        update_hash(" %10s" % pwd.getpwuid(s.st_uid).pw_name)
     0549:                        update_hash(" %10s" % grp.getgrgid(s.st_gid).gr_name)
     0550:                    except KeyError:
     0551:                        bb.warn("KeyError in %s" % path)
     0552:                        raise
Exception: KeyError: 'getpwuid(): uid not found: 1234'

ERROR: Logfile of failure stored in: /dunfell/build/tmp/work/x86_64-nativesdk-pokysdk-linux/gdb-cross-canadian-arm/9.1-r0/temp/log.do_package.32445
ERROR: Task (/dunfell/sources/poky/meta/recipes-devtools/gdb/gdb-cross-canadian_9.1.bb:do_package) failed with exit code '1'