### PR TITLE
openocd-stm32mp: disable ccache, plus some improvements to the recipe

### DIFF
--- a/recipes-devtools/openocd/openocd-stm32mp.inc
+++ b/recipes-devtools/openocd/openocd-stm32mp.inc
@@ -1,3 +1,7 @@
+DEPENDS = "hidapi-stm32mp"
+
+RDEPENDS_${PN} = "libusb1 hidapi-stm32mp"
+
 inherit pkgconfig autotools-brokensep gettext
 
 SRC_URI = " \
@@ -14,13 +18,8 @@ S = "${WORKDIR}/git"
 
 BBCLASSEXTEND += "native nativesdk"
 
-DEPENDS += "hidapi-stm32mp"
-DEPENDS_class-native = "hidapi-stm32mp-native"
-DEPENDS_class-nativesdk = "nativesdk-hidapi-stm32mp"
-
-RDEPENDS_${PN} += "libusb1 hidapi-stm32mp"
-
 EXTRA_OECONF = " \
+    --disable-doxygen-html \
     --disable-werror \
     --enable-stlink \
     --enable-cmsis-dap \
@@ -51,3 +50,6 @@ FILES_${PN} = " \
   ${datadir}/openocd/* \
   ${bindir}/openocd \
   "
+
+# Can't be built with ccache
+CCACHE_DISABLE = "1"

--- a/recipes-devtools/openocd/openocd-stm32mp_0.10.0.bb
+++ b/recipes-devtools/openocd/openocd-stm32mp_0.10.0.bb
@@ -5,12 +5,14 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
 
 require openocd-stm32mp.inc
 
-SRC_URI_prepend = " git://repo.or.cz/openocd.git;name=openocd "
+SRC_URI_prepend = "git://repo.or.cz/openocd.git;name=openocd "
 
 SRCREV_FORMAT = "openocd"
 SRCREV_openocd = "b5d2b1224fed3909aa3314339611ac5ac7ab0f82"
 
 PV = "0.10.0-release.${SRCPV}"
 
-SRC_URI += "file://0001-M4-visible-rebase-on-b5d2b1224fed-fixes.patch"
-SRC_URI += "file://0002-fixes-for-gcc-10-build-macos-build-CM4-halt-stlink-J.patch"
+SRC_URI += " \
+    file://0001-M4-visible-rebase-on-b5d2b1224fed-fixes.patch \
+    file://0002-fixes-for-gcc-10-build-macos-build-CM4-halt-stlink-J.patch \
+"


### PR DESCRIPTION
When ccache is enabled the following error occurs, adding CCACHE_DISABLE = "1"
in the recipe avoid this.

| Host System...x86_64-pc-linux-gnu
| Build System...x86_64-pc-linux-gnu
| C compiler...ccache ccache gcc  -isystem/src/build/tmp/work/x86_64-linux/openocd-stm32mp-native/0.10.0-release.AUTOINC+b5d2b1224f-r0/recipe-sysroot-native/usr/include -O2 -pipe
| C++ compiler...ccache ccache g++  -isystem/src/build/tmp/work/x86_64-linux/openocd-stm32mp-native/0.10.0-release.AUTOINC+b5d2b1224f-r0/recipe-sysroot-native/usr/include -O2 -pipe
| Build C compiler...ccache gcc
| Checking for stdlib.h...not found
| Error: Compiler does not work. See config.log
| Try: 'configure --help' for options
| configure: error: ./configure.gnu failed for jimtcl
| WARNING: exit code 1 from a shell command.
|

In addition, push some improvements to the recipe.

Signed-off-by: Thomas Perrot <thomas.perrot@bootlin.com>