### PR TITLE
u-boot-stm32mp: add patch to allow compilation with gcc10

### DIFF
--- a/recipes-bsp/u-boot/u-boot-stm32mp-common_2020.01.inc
+++ b/recipes-bsp/u-boot/u-boot-stm32mp-common_2020.01.inc
@@ -28,6 +28,7 @@ SRC_URI += "\
     file://0010-ARM-v2020.01-stm32mp-r2-CONFIG.patch \
     \
     file://0099-Add-external-var-to-allow-build-of-new-devicetree-fi.patch \
+    file://remove-redundant-yyloc-global.patch \
 "
 
 U_BOOT_VERSION = "2020.01"

--- a/recipes-bsp/u-boot/u-boot-stm32mp/remove-redundant-yyloc-global.patch
+++ b/recipes-bsp/u-boot/u-boot-stm32mp/remove-redundant-yyloc-global.patch
@@ -1,0 +1,27 @@
+From 018921ee79d3f30893614b3b2b63b588d8544f73 Mon Sep 17 00:00:00 2001
+From: Peter Robinson <pbrobinson@gmail.com>
+Date: Thu, 30 Jan 2020 09:37:15 +0000
+Subject: [PATCH] Remove redundant YYLOC global declaration
+
+Same as the upstream fix for building dtc with gcc 10.
+
+Signed-off-by: Peter Robinson <pbrobinson@gmail.com>
+---
+ scripts/dtc/dtc-lexer.l | 1 -
+ 1 file changed, 1 deletion(-)
+
+diff --git a/scripts/dtc/dtc-lexer.l b/scripts/dtc/dtc-lexer.l
+index fd825ebba6..24af549977 100644
+--- a/scripts/dtc/dtc-lexer.l
++++ b/scripts/dtc/dtc-lexer.l
+@@ -38,7 +38,6 @@ LINECOMMENT	"//".*\n
+ #include "srcpos.h"
+ #include "dtc-parser.tab.h"
+ 
+-YYLTYPE yylloc;
+ extern bool treesource_error;
+ 
+ /* CAUTION: this will stop working if we ever use yyless() or yyunput() */
+-- 
+2.26.2
+


### PR DESCRIPTION
Patch was taken from poky u-boot recipe. Original error message:
multiple definition of `yylloc'