### PR TITLE
sdcard-raw-tools: add extra space with append on rdepends

### DIFF
--- a/recipes-devtools/sdcard-raw-tools/sdcard-raw-tools.bb
+++ b/recipes-devtools/sdcard-raw-tools/sdcard-raw-tools.bb
@@ -9,7 +9,7 @@ SRC_URI = "file://create_sdcard_from_flashlayout.sh"
 
 BBCLASSEXTEND = "native nativesdk"
 
-RDEPENDS_${PN}_append = "bash"
+RDEPENDS_${PN}_append = " bash"
 
 RRECOMMENDS_${PN}_append_class-nativesdk = "nativesdk-gptfdisk"
 


### PR DESCRIPTION
When trying to build with a more recent OE-master version, bitbake ended
up having an issue parsing the rdepends for the target and native build
targets due lack of space when appending bash to rdepends.

Fix by just adding the extra space required when appending values to a
variable.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>