### PR TITLE
wic: use part-name fip for fip (instead of ssbl)

### DIFF
--- a/wic/sdcard-stm32mp157c-dk2-optee-1GB.wks.in
+++ b/wic/sdcard-stm32mp157c-dk2-optee-1GB.wks.in
@@ -8,12 +8,12 @@
 # | |     |         |      |      |      |             |             |         |        |
 # 0 17kB 529kB    2.5MB   2.8MB  3MB    3.3MB        67.3MiB       83.3MB    851.3Mb  1024MB
 #
-# Warning: the first stage of boot (here fsbl1, fsbl2, ssbl) MUST be on GPT partition to be detected.
+# Warning: the first stage of boot (here fsbl1, fsbl2, fip) MUST be on GPT partition to be detected.
 #
 
 part fsbl1 --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fsbl1 --sourceparams="file=${DEPLOY_DIR_IMAGE}/arm-trusted-firmware/tf-a-stm32mp157c-dk2-sdcard.stm32" --ondisk mmcblk --part-type 0x8301 --fixed-size 256K --align 17
 part fsbl2 --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fsbl2 --sourceparams="file=${DEPLOY_DIR_IMAGE}/arm-trusted-firmware/tf-a-stm32mp157c-dk2-sdcard.stm32" --ondisk mmcblk --part-type 0x8301 --fixed-size 256K
-part ssbl  --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=ssbl --sourceparams="file=${DEPLOY_DIR_IMAGE}/fip/fip-stm32mp157c-dk2-optee.bin" --ondisk mmcblk --part-type 0x8301 --fixed-size 4096K
+part fip   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip --sourceparams="file=${DEPLOY_DIR_IMAGE}/fip/fip-stm32mp157c-dk2-optee.bin" --ondisk mmcblk --part-type 0x8301 --fixed-size 4096K
 
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M
 part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size 768M

--- a/wic/sdcard-stm32mp157c-dk2-optee-vendorfs-1GB.wks.in
+++ b/wic/sdcard-stm32mp157c-dk2-optee-vendorfs-1GB.wks.in
@@ -8,12 +8,12 @@
 # | |     |         |      |      |      |             |             |         |        |
 # 0 17kB 529kB    2.5MB   2.8MB  3MB    3.3MB        67.3MiB       83.3MB    851.3Mb  1024MB
 #
-# Warning: the first stage of boot (here fsbl1, fsbl2, ssbl) MUST be on GPT partition to be detected.
+# Warning: the first stage of boot (here fsbl1, fsbl2, fip) MUST be on GPT partition to be detected.
 #
 
 part fsbl1 --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fsbl1 --sourceparams="file=${DEPLOY_DIR_IMAGE}/arm-trusted-firmware/tf-a-stm32mp157c-dk2-sdcard.stm32" --ondisk mmcblk --part-type 0x8301 --fixed-size 256K --align 17
 part fsbl2 --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fsbl2 --sourceparams="file=${DEPLOY_DIR_IMAGE}/arm-trusted-firmware/tf-a-stm32mp157c-dk2-sdcard.stm32" --ondisk mmcblk --part-type 0x8301 --fixed-size 256K
-part ssbl  --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=ssbl --sourceparams="file=${DEPLOY_DIR_IMAGE}/fip/fip-stm32mp157c-dk2-optee.bin" --ondisk mmcblk --part-type 0x8301 --fixed-size 4096K
+part fip   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip --sourceparams="file=${DEPLOY_DIR_IMAGE}/fip/fip-stm32mp157c-dk2-optee.bin" --ondisk mmcblk --part-type 0x8301 --fixed-size 4096K
 
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M
 part vendorfs --source rawcopy --sourceparams="file=st-image-vendorfs-${DISTRO}-${MACHINE}.ext4" --ondisk mmcblk --fstype=ext4 --label vendorfs --active --fixed-size 16M

--- a/wic/sdcard-stm32mp157c-dk2-trusted-1GB.wks.in
+++ b/wic/sdcard-stm32mp157c-dk2-trusted-1GB.wks.in
@@ -8,12 +8,12 @@
 # | |     |         |              |             |         |        |
 # 0 17kB 529kB     4MB           66.5MB        82.5MB   850.5Mb  1024MB
 #
-# Warning: the first stage of boot (here fsbl1, fsbl2, ssbl) MUST be on GPT partition to be detected.
+# Warning: the first stage of boot (here fsbl1, fsbl2, fip) MUST be on GPT partition to be detected.
 #
 
 part fsbl1 --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fsbl1 --sourceparams="file=${DEPLOY_DIR_IMAGE}/arm-trusted-firmware/tf-a-stm32mp157c-dk2-sdcard.stm32" --ondisk mmcblk --part-type 0x8301 --fixed-size 256K --align 17
 part fsbl2 --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fsbl2 --sourceparams="file=${DEPLOY_DIR_IMAGE}/arm-trusted-firmware/tf-a-stm32mp157c-dk2-sdcard.stm32" --ondisk mmcblk --part-type 0x8301 --fixed-size 256K
-part ssbl  --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=ssbl --sourceparams="file=${DEPLOY_DIR_IMAGE}/fip/fip-stm32mp157c-dk2-trusted.bin" --ondisk mmcblk --part-type 0x8301 --fixed-size 4096K
+part fip   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip --sourceparams="file=${DEPLOY_DIR_IMAGE}/fip/fip-stm32mp157c-dk2-trusted.bin" --ondisk mmcblk --part-type 0x8301 --fixed-size 4096K
 
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M
 part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size 768M

--- a/wic/sdcard-stm32mp157c-dk2-trusted-vendorfs-1GB.wks.in
+++ b/wic/sdcard-stm32mp157c-dk2-trusted-vendorfs-1GB.wks.in
@@ -8,12 +8,12 @@
 # | |     |         |              |             |         |        |
 # 0 17kB 529kB     4MB           66.5MB        82.5MB   850.5Mb  1024MB
 #
-# Warning: the first stage of boot (here fsbl1, fsbl2, ssbl) MUST be on GPT partition to be detected.
+# Warning: the first stage of boot (here fsbl1, fsbl2, fip) MUST be on GPT partition to be detected.
 #
 
 part fsbl1 --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fsbl1 --sourceparams="file=${DEPLOY_DIR_IMAGE}/arm-trusted-firmware/tf-a-stm32mp157c-dk2-sdcard.stm32" --ondisk mmcblk --part-type 0x8301 --fixed-size 256K --align 17
 part fsbl2 --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fsbl2 --sourceparams="file=${DEPLOY_DIR_IMAGE}/arm-trusted-firmware/tf-a-stm32mp157c-dk2-sdcard.stm32" --ondisk mmcblk --part-type 0x8301 --fixed-size 256K
-part ssbl  --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=ssbl --sourceparams="file=${DEPLOY_DIR_IMAGE}/fip/fip-stm32mp157c-dk2-trusted.bin" --ondisk mmcblk --part-type 0x8301 --fixed-size 4096K
+part fip   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip --sourceparams="file=${DEPLOY_DIR_IMAGE}/fip/fip-stm32mp157c-dk2-trusted.bin" --ondisk mmcblk --part-type 0x8301 --fixed-size 4096K
 
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M
 part vendorfs --source rawcopy --sourceparams="file=st-image-vendorfs-${DISTRO}-${MACHINE}.ext4" --ondisk mmcblk --fstype=ext4 --label vendorfs --active --fixed-size 16M


### PR DESCRIPTION
Use fip as part-name for fip otherwise tf-a is unable to find the fip
partition:

ERROR:   Could NOT find the fip partition!
ERROR:   BL2: Failure in pre image load handling (-2)

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>