### PR TITLE
MACHINE: select type of boot image in machine conf

### DIFF
--- a/conf/machine/include/st-machine-common-stm32mp.inc
+++ b/conf/machine/include/st-machine-common-stm32mp.inc
@@ -47,9 +47,6 @@ DISTRO_EXTRA_RRECOMMENDS:remove = " ${@bb.utils.contains('COMBINED_FEATURES', 'i
 # Configure autoresize for any of the 'ext4' storage devices (through InitRD image)
 MACHINE_FEATURES:append = " ${@bb.utils.contains_any('BOOTDEVICE_LABELS',  ['emmc', 'sdcard'], 'autoresize', '', d)} "
 
-# Use FIP image for boot loaders
-MACHINE_FEATURES += "fip"
-
 # Default serial consoles (TTYs) to enable using getty
 # Before kernel 4.18, serial console are ttyS3 but after is ttySTM0
 SERIAL_CONSOLES = "115200;ttySTM0"

--- a/conf/machine/stm32mp15-disco.conf
+++ b/conf/machine/stm32mp15-disco.conf
@@ -49,6 +49,8 @@ MACHINE_FEATURES += "bluetooth"
 MACHINE_FEATURES += "wifi"
 MACHINE_FEATURES += "${@'gpu' if d.getVar('ACCEPT_EULA_'+d.getVar('MACHINE')) == '1' else ''}"
 MACHINE_FEATURES += "m4copro"
+# Use FIP image for boot loaders
+MACHINE_FEATURES += "fip"
 
 # Bluetooth
 BLUETOOTH_LIST += "linux-firmware-bluetooth-bcm4343"

--- a/conf/machine/stm32mp15-eval.conf
+++ b/conf/machine/stm32mp15-eval.conf
@@ -49,9 +49,9 @@ MACHINE_FEATURES += "watchdog"
 #MACHINE_FEATURES += "wifi"
 MACHINE_FEATURES += "${@'gpu' if d.getVar('ACCEPT_EULA_'+d.getVar('MACHINE')) == '1' else ''}"
 MACHINE_FEATURES += "m4copro"
+# Use FIT image for boot loaders
 MACHINE_FEATURES += "fit"
 
-MACHINE_FEATURES:remove = "fip"
 
 # Bluetooth
 #BLUETOOTH_LIST += "linux-firmware-bluetooth-bcm4343"


### PR DESCRIPTION
Don't force FIP boot image in the common machine include, instead
select it in the final machine defitions.

This change permits to override machine configuration settings correctly
in other meta layers, for example:

MACHINE_FEATURES:remove:stm32mp15-eval = "fit"
MACHINE_FEATURES:append:stm32mp15-eval = "fip"

Signed-off-by: Igor Opaniuk <igor.opaniuk@foundries.io>