### PR TITLE
libdrm: set PACKAGECONFIG based on stm32mpcommon

### DIFF
--- a/recipes-graphics/drm/libdrm_2.4.110.bbappend
+++ b/recipes-graphics/drm/libdrm_2.4.110.bbappend
@@ -1,5 +1,5 @@
 # We don't want etnaviv drm package
-PACKAGECONFIG = "libkms install-test-programs"
+PACKAGECONFIG:stm32mpcommon = "libkms install-test-programs"
 
 FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}/:"
 


### PR DESCRIPTION
Don't override the default settings in order to avoid conflicts with
other layers, and make the custom PACKAGECONFIG changes specific to
stm32mpcommon.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>