### PR TITLE
mesa: drop dri from PACKAGECONFIG

### DIFF
--- a/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-graphics/mesa/mesa_%.bbappend
@@ -1,7 +1,7 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/mesa:"
 
 PACKAGECONFIG:stm32mpcommon = "${@bb.utils.filter('DISTRO_FEATURES', 'wayland ', d)} \
-                 ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'opengl egl gles gbm dri', '', d)} \
+                 ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'opengl egl gles gbm', '', d)} \
                  ${@bb.utils.contains('DISTRO_FEATURES', 'x11 opengl', 'x11', '', d)} \
                  ${@bb.utils.contains('DISTRO_FEATURES', 'x11 vulkan', 'dri3', '', d)} \
                 \


### PR DESCRIPTION
Removed since mesa 22.0.0.

Fixes:
WARNING: mesa-2_22.0.3-r0 do_configure: QA Issue: mesa: invalid
PACKAGECONFIG: dri [invalid-packageconfig]

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>