### PR TITLE
GCNANO-USERLAND: add libgles2 compatibility with third-party software

### DIFF
--- a/recipes-graphics/gcnano-userland/gcnano-userland.inc
+++ b/recipes-graphics/gcnano-userland/gcnano-userland.inc
@@ -122,6 +122,8 @@ gcnano_install_lib() {
                 install -m 0555 ${gcnano_libdir}/libGLSLC.so ${gcnano_libdir_install}/
                 find ${gcnano_libdir}/* -type f -name libGLESv2.so* -exec install -m 0555 '{}' ${gcnano_libdir_install}/ \;
                 find ${gcnano_libdir}/* -type l -name libGLESv2.so* -exec cp -d '{}' ${gcnano_libdir_install}/ \;
+                # Create symlink for compatibility with third-party software
+                ln -srf ${gcnano_libdir_install}/libGLESv2.so ${gcnano_libdir_install}/libGLESv2.so.2
                 # Install includes
                 install -m 0755 -d ${gcnano_incdir_install}/GLES2
                 install -m 0644 ${gcnano_incdir}/GLES2/* ${gcnano_incdir_install}/GLES2
@@ -234,7 +236,7 @@ FILES:libegl-gcnano = "${GCNANO_USERLAND_OUTPUT_LIBDIR}/libEGL.so*"
 FILES:libgbm-gcnano = "${GCNANO_USERLAND_OUTPUT_LIBDIR}/libgbm.so*"
 FILES:libgbm-gcnano += "${GCNANO_USERLAND_OUTPUT_LIBDIR}/libgbm_viv.so"
 FILES:libgles1-gcnano = "${GCNANO_USERLAND_OUTPUT_LIBDIR}/libGLESv1*.so"
-FILES:libgles2-gcnano = "${GCNANO_USERLAND_OUTPUT_LIBDIR}/libGLESv2.so"
+FILES:libgles2-gcnano = "${GCNANO_USERLAND_OUTPUT_LIBDIR}/libGLESv2.so*"
 FILES:libgles2-gcnano += "${GCNANO_USERLAND_OUTPUT_LIBDIR}/libGLSLC.so"
 FILES:libopenvg-gcnano = "${GCNANO_USERLAND_OUTPUT_LIBDIR}/libOpenVG*.so*"
 


### PR DESCRIPTION
This commit reintroduces a missing lib for libgles2 to keep compatibility with
third-party software, as in commit 16e357f("GCNANO-UERLAND: cleanup and link
creation") it was removed in the refactoring process.

Signed-off-by: Arturo Buzarra <arturo.buzarra@digi.com>