### PR TITLE
make-mod-scripts: drop bbappends

### DIFF
--- a/recipes-kernel/make-mod-scripts/make-mod-scripts_%.bbappend
+++ b/recipes-kernel/make-mod-scripts/make-mod-scripts_%.bbappend
@@ -1,8 +1,0 @@
-do_configure:prepend:stm32mpcommon() {
-    PLUGIN_PATH=$(${CC} -print-file-name=plugin)
-    if [ -e "${PLUGIN_PATH}/include/plugin-version.h" ]; then
-        bbnote "Will remove ${PLUGIN_PATH}/include/plugin-version.h"
-        rm -f ${PLUGIN_PATH}/include/plugin-version.h
-    fi
-}
-


### PR DESCRIPTION
Remove local bbappends to allow support for GCC plugins.

There is no description to why this bbappends was created, so unclear
what justified it.

Signed-off-by: Ricardo Salveti <ricardo@foundries.io>