### PR TITLE
st-image-partitions.inc: Avoid circular references

### DIFF
--- a/recipes-st/images/st-image-partitions.inc
+++ b/recipes-st/images/st-image-partitions.inc
@@ -65,3 +65,6 @@ reformat_rootfs() {
         bbnote "${IMAGE_PARTITION_MOUNTPOINT} folder not available in rootfs folder, no reformat done..."
     fi
 }
+
+# noexec do_image_wic task to avoid circular references
+do_image_wic[noexec] = "1"


### PR DESCRIPTION
If IMAGE_FSTYPES contains wic, st-image-* will be error on do_image_wic. 
Because do_image_wic tasks are circular references between each st-image-*. 
However wks expects it generates st-image*.ext4 not wic. 
Thus do_image_wic are not need with st-image-* .
Then set the noexec flag to do_image_wic of st-image-* to disable the task.

I think if wic image creation is possible, do not need the create_sdcard_from_flashlayout.sh and *.tsv files.
Because these files are redundant to creating the SD card image.