### PR TITLE
OPENOCD: 0.11.0 fix PV

### DIFF
--- a/recipes-devtools/openocd/openocd-stm32mp.inc
+++ b/recipes-devtools/openocd/openocd-stm32mp.inc
@@ -4,15 +4,12 @@ RDEPENDS:${PN} += "libusb1 hidapi-stm32mp"
 
 inherit pkgconfig autotools-brokensep gettext
 
+SRC_URI = "git://github.com/openocd-org/openocd.git;protocol=https;branch=master;name=openocd "
 SRC_URI:append = " \
     git://git.savannah.nongnu.org/git/git2cl.git;protocol=https;;destsuffix=git/tools/git2cl;nobranch=1;name=git2cl         \
     git://github.com/msteveb/jimtcl.git;protocol=https;destsuffix=git/jimtcl;nobranch=1;name=jimtcl                         \
     git://gitlab.zapb.de/libjaylink/libjaylink.git;protocol=https;destsuffix=git/src/jtag/drivers/libjaylink;nobranch=1;name=libjaylink \
     "
-
-SRCREV_git2cl = "8373c9f74993e218a08819cbcdbab3f3564bbeba"
-SRCREV_jimtcl = "3920cedd1cdd4702720773f0637b780f79be6158"
-SRCREV_libjaylink = "9aa7a5957c07bb6e862fc1a6d3153d109c7407e4"
 
 S = "${WORKDIR}/git"
 

--- a/recipes-devtools/openocd/openocd-stm32mp_0.11.0.bb
+++ b/recipes-devtools/openocd/openocd-stm32mp_0.11.0.bb
@@ -5,19 +5,15 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=599d2d1ee7fc84c0467b3d19801db870"
 
 require openocd-stm32mp.inc
 
-SRC_URI = "git://github.com/openocd-org/openocd.git;protocol=https;branch=master;name=openocd "
 
 SRCREV_FORMAT = "openocd"
 SRCREV_openocd = "fdf17dba569ac8aca0771c28b661e3722d776541"
+SRCREV_git2cl = "8373c9f74993e218a08819cbcdbab3f3564bbeba"
+SRCREV_jimtcl = "3920cedd1cdd4702720773f0637b780f79be6158"
+SRCREV_libjaylink = "9aa7a5957c07bb6e862fc1a6d3153d109c7407e4"
 
-PV = "0.11.0+dev.${SRCPV}"
+PV = "0.11.0+dev"
 
 SRC_URI += ""
 
-# Use jimtcl master branch to fix RANLIB issue in kirkstone and commit it
-# to prevent "-dirty" suffix to openocd version.
-# To be removed after a new jimtcl release get used by openocd.
-do_configure:prepend() {
-	git add jimtcl
-	git commit -m "Update jimtcl"
-}
+


### PR DESCRIPTION
Fix building when git user has not been configured: $ bitbake openocd-stm32mp-native
ERROR: openocd-stm32mp-native-0.11.0+dev.AUTOINC+fdf17dba56-r0 do_configure: ...
| DEBUG: Executing shell function do_configure
| Author identity unknown
|
| *** Please tell me who you are.
|
| Run
|
|   git config --global user.email "you@example.com"
|   git config --global user.name "Your Name"
|
| to set your account's default identity.
| Omit --global to set the identity only in this repository.
|
| fatal: unable to auto-detect email address (got 'testuser@localhost.(none)')
| WARNING: exit code 128 from a shell command.

This change PV to 0.11.0+dev as using a fix baseline is misleading: we use a modified version of jimtcl submodule on top of the specified version of openocd