### PR TITLE
README:  Changing [META-OPENEMBEDDED] URI's protocol from git to https.

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ revision: HEAD
 
 ```
 [META-OPENEMBEDDED]
-URI: git://github.com/openembedded/meta-openembedded.git
+URI: https://github.com/openembedded/meta-openembedded.git
 layers: meta-python meta-oe
 branch: same dedicated branch as meta-st-stm32mp
 revision: HEAD


### PR DESCRIPTION
README:  Changing [META-OPENEMBEDDED] URI's protocol from git to https, because github doesn't accept cloning using git protocol, only https.