### PR TITLE
alsa-lib: add Upstream-Status to the patches

### DIFF
--- a/recipes-bsp/alsa/alsa-lib/0001-conf-add-card-configs-for-stm32mp15x-boards.patch
+++ b/recipes-bsp/alsa/alsa-lib/0001-conf-add-card-configs-for-stm32mp15x-boards.patch
@@ -6,6 +6,8 @@ Subject: [PATCH 1/2] conf: add card configs for stm32mp15x boards
 Add card configuration files for STM32MP15x-EV
 and STM32MP15x-DK boards.
 
+Upstream-Status: Pending
+
 Signed-off-by: Olivier Moysan <olivier.moysan@st.com>
 ---
  src/conf/cards/Makefile.am      |  4 ++-

--- a/recipes-bsp/alsa/alsa-lib/0002-conf-add-card-config-for-stm32mp13x_evd-board.patch
+++ b/recipes-bsp/alsa/alsa-lib/0002-conf-add-card-config-for-stm32mp13x_evd-board.patch
@@ -5,6 +5,8 @@ Subject: [PATCH 2/2] conf: add card config for stm32mp13x_evd board
 
 Add card configuration file for STM32MP13x-EVD board.
 
+Upstream-Status: Pending
+
 Signed-off-by: Olivier Moysan <olivier.moysan@st.com>
 ---
  src/conf/cards/Makefile.am       |  3 +-


### PR DESCRIPTION
Fixing the build when using oe-core master branch:
```
ERROR: alsa-lib-1.2.9-r0 do_patch: QA Issue: Missing Upstream-Status in patch
/build-lmp-stm32mp15-disco-main-next/conf/../../layers/meta-st-stm32mp/recipes-bsp/alsa/alsa-lib/0001-conf-add-card-configs-for-stm32mp15x-boards.patch
Please add according to https://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines#Patch_Header_Recommendations:_Upstream-Status . [patch-status]
ERROR: alsa-lib-1.2.9-r0 do_patch: QA Issue: Missing Upstream-Status in patch
/build-lmp-stm32mp15-disco-main-next/conf/../../layers/meta-st-stm32mp/recipes-bsp/alsa/alsa-lib/0002-conf-add-card-config-for-stm32mp13x_evd-board.patch
Please add according to https://www.openembedded.org/wiki/Commit_Patch_Message_Guidelines#Patch_Header_Recommendations:_Upstream-Status . [patch-status]
ERROR: alsa-lib-1.2.9-r0 do_patch: Fatal QA errors were found, failing task.
ERROR: Logfile of failure stored in: /build-lmp-stm32mp15-disco-main-next/tmp-lmp/work/cortexa7t2hf-neon-vfpv4-lmp-linux-gnueabi/alsa-lib/1.2.9-r0/temp/log.do_patch.559211
ERROR: Task (/build-lmp-stm32mp15-disco-main-next/conf/../../layers/openembedded-core/meta/recipes-multimedia/alsa/alsa-lib_1.2.9.bb:do_patch) failed with exit code '1'
```