### PR TITLE
Add support for KAS utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,42 @@ revision: HEAD
 
 The dependency (meta-python) are due to the usage of OPTEE which require to use some python packages.
 
+### Kas Support
+
+If you are familiar with `kas` tool, you can use it to setup this layer only or other custom layer that includes this layer's `kas` configuration.
+
+* To build images provided by this layer (`stm32mp1` machine is supported):
+
+```sh
+git clone https://github.com/STMicroelectronics/meta-st-stm32mp -b <branch>
+kas build meta-st-stm32mp/kas/kas-st-stm32mp1-##image##.yml
+```
+
+for `##image##` is one of: `bootfs`, `userfs` or `vendorfs`.
+
+* To use `kas` from another custom layer that uses this layer, `kas` supports including a file from another layer that is not the one containing your `kas` files.
+
+**Example**:
+
+* `meta-custom/kas-custom-image.yml`
+
+```yaml
+head:
+  version: 5
+  includes:
+    - repo: meta-st-stm32mp
+      file: kas/include/kas-st.yml
+
+repos:
+  meta-st-stm32mp:
+    url: https://github.com/STMicroelectronics/meta-st-stm32mp
+    path: layers
+    refspec: kirkstone
+
+target: custom-image
+machine: stm32mp1
+```
+
 ## EULA
 
 Some SoC depends on firmware and/or packages that are covered by

--- a/kas/include/common/local.yml
+++ b/kas/include/common/local.yml
@@ -1,0 +1,23 @@
+header:
+  version: 5
+
+local_conf_header:
+  default: |
+    # -- Default local.conf from meta-poky/conf/local.conf.sample -- #
+    EXTRA_IMAGE_FEATURES ?= "debug-tweaks"
+    USER_CLASSES ?= "buildstats"
+    PATCHRESOLVE = "noop"
+    BB_DISKMON_DIRS ??= "\
+        STOPTASKS,${TMPDIR},1G,100K \
+        STOPTASKS,${DL_DIR},1G,100K \
+        STOPTASKS,${SSTATE_DIR},1G,100K \
+        STOPTASKS,/tmp,100M,100K \
+        HALT,${TMPDIR},100M,1K \
+        HALT,${DL_DIR},100M,1K \
+        HALT,${SSTATE_DIR},100M,1K \
+        HALT,/tmp,10M,1K"
+    PACKAGECONFIG:append:pn-qemu-system-native = " sdl"
+    CONF_VERSION = "2"
+
+    DL_DIR = "/home/talel/Desktop/YoctoShare/downloads"
+    SSTATE_DIR = "/home/talel/Desktop/YoctoShare/sstate-cache"

--- a/kas/include/common/local.yml
+++ b/kas/include/common/local.yml
@@ -18,6 +18,3 @@ local_conf_header:
         HALT,/tmp,10M,1K"
     PACKAGECONFIG:append:pn-qemu-system-native = " sdl"
     CONF_VERSION = "2"
-
-    DL_DIR = "/home/talel/Desktop/YoctoShare/downloads"
-    SSTATE_DIR = "/home/talel/Desktop/YoctoShare/sstate-cache"

--- a/kas/include/common/oe.yml
+++ b/kas/include/common/oe.yml
@@ -1,0 +1,20 @@
+header:
+  version: 5
+
+repos:
+  poky:
+    url: https://git.yoctoproject.org/git/poky
+    path: layers/poky
+    refspec: kirkstone
+    layers:
+      meta:
+      meta-poky:
+      meta-yocto-bsp:
+
+  meta-openembedded:
+    url: https://git.openembedded.org/meta-openembedded
+    path: layers/meta-openembedded
+    refspec: kirkstone
+    layers:
+      meta-oe:
+      meta-python:

--- a/kas/include/common/stm32mp.yml
+++ b/kas/include/common/stm32mp.yml
@@ -1,0 +1,5 @@
+header:
+  version: 5
+
+repos:
+  meta-st-stm32mp:

--- a/kas/include/kas-st-bootfs.yml
+++ b/kas/include/kas-st-bootfs.yml
@@ -1,0 +1,6 @@
+header:
+  version: 5
+  includes:
+    - kas-st.yml
+
+target: st-image-bootfs

--- a/kas/include/kas-st-userfs.yml
+++ b/kas/include/kas-st-userfs.yml
@@ -1,0 +1,6 @@
+header:
+  version: 5
+  includes:
+    - kas-st.yml
+
+target: st-image-userfs

--- a/kas/include/kas-st-vendorfs.yml
+++ b/kas/include/kas-st-vendorfs.yml
@@ -1,0 +1,6 @@
+header:
+  version: 5
+  includes:
+    - kas-st.yml
+
+target: st-image-vendorfs

--- a/kas/include/kas-st.yml
+++ b/kas/include/kas-st.yml
@@ -1,0 +1,8 @@
+header:
+  version: 5
+  includes:
+    - common/oe.yml
+    - common/local.yml
+    - common/stm32mp.yml
+
+distro: poky

--- a/kas/kas-st-stm32mp1-bootfs.yml
+++ b/kas/kas-st-stm32mp1-bootfs.yml
@@ -1,0 +1,6 @@
+header:
+  version: 5
+  includes:
+    - include/kas-st-bootfs.yml
+
+machine: stm32mp1

--- a/kas/kas-st-stm32mp1-userfs.yml
+++ b/kas/kas-st-stm32mp1-userfs.yml
@@ -1,0 +1,6 @@
+header:
+  version: 5
+  includes:
+    - include/kas-st-userfs.yml
+
+machine: stm32mp1

--- a/kas/kas-st-stm32mp1-vendorfs.yml
+++ b/kas/kas-st-stm32mp1-vendorfs.yml
@@ -1,0 +1,6 @@
+header:
+  version: 5
+  includes:
+    - include/kas-st-vendorfs.yml
+
+machine: stm32mp1


### PR DESCRIPTION
* Kas utility will help developers setup the environment and the build process.

* This commit adds support for this layer which is the one and only BSP layer for `STM32MP` boards, and other layers can include these kas files easily as mentionned in the README example.

* (Kas Support) part is added to the README file

* If this is accepted, I will add Kas support also for the famous (meta-st-openstlinux) layer (or probably other layers as well).

* I tested this setup building bootfs, vendorfs and userfs images with the following commands:

	1- kas build meta-st-stm32mp/kas/kas-st-stm32mp1-bootfs.yml
	2- kas build meta-st-stm32mp/kas/kas-st-stm32mp1-vendorfs.yml
	3- kas build meta-st-stm32mp/kas/kas-st-stm32mp1-userfs.yml