### PR TITLE
Bugfix u-boot-env, make PARTUUID assignable system-wide 

### DIFF
--- a/conf/machine/include/st-machine-extlinux-config-stm32mp.inc
+++ b/conf/machine/include/st-machine-extlinux-config-stm32mp.inc
@@ -38,9 +38,9 @@ UBOOT_EXTLINUX_BOOTPREFIXES:target-emmc = "${DEVICE:EMMC}_"
 UBOOT_EXTLINUX_BOOTPREFIXES:target-nand = "${DEVICE:NAND}_"
 # Define ROOT overrides for each target
 UBOOT_EXTLINUX_ROOT:target-nand = "ubi.mtd=UBI rootfstype=ubifs root=ubi0:rootfs"
-UBOOT_EXTLINUX_ROOT:target-sdcard = "root=PARTUUID=${DEVICE_PARTUUID_ROOTFS:SDCARD}"
+UBOOT_EXTLINUX_ROOT:target-sdcard ??= "root=PARTUUID=${DEVICE_PARTUUID_ROOTFS:SDCARD}"
 UBOOT_EXTLINUX_ROOT:target-nor = "root=/dev/mtdblock6"
-UBOOT_EXTLINUX_ROOT:target-emmc = "root=PARTUUID=${DEVICE_PARTUUID_ROOTFS:EMMC}"
+UBOOT_EXTLINUX_ROOT:target-emmc ??= "root=PARTUUID=${DEVICE_PARTUUID_ROOTFS:EMMC}"
 # Define INITRD overrides for nand target
 UBOOT_EXTLINUX_INITRD:target-nand = ""
 

--- a/wic/sdcard-stm32mp135f-dk-optee-1GB.wks.in
+++ b/wic/sdcard-stm32mp135f-dk-optee-1GB.wks.in
@@ -24,7 +24,7 @@ part fip-a   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip
 part fip-b   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip-b --sourceparams="file=${DEPLOY_DIR_IMAGE}/fip/fip-stm32mp135f-dk-optee.bin" --ondisk mmcblk --part-type 19d5df83-11b0-457b-be2c-7559c13142a5 --fixed-size 4096K --uuid 09c54952-d5bf-45af-acee-335303766fb3
 
 # U-BOOT env
-part u-boot-env --source empty --part-name=uboot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
+part u-boot-env --source empty --part-name=${STM32MP_UENV_NAME} --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
 
 # Bootfs
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M

--- a/wic/sdcard-stm32mp135f-dk-optee-vendorfs-1GB.wks.in
+++ b/wic/sdcard-stm32mp135f-dk-optee-vendorfs-1GB.wks.in
@@ -24,7 +24,7 @@ part fip-a   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip
 part fip-b   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip-b --sourceparams="file=${DEPLOY_DIR_IMAGE}/fip/fip-stm32mp135f-dk-optee.bin" --ondisk mmcblk --part-type 19d5df83-11b0-457b-be2c-7559c13142a5 --fixed-size 4096K --uuid 09c54952-d5bf-45af-acee-335303766fb3
 
 # U-BOOT env
-part u-boot-env --source empty --part-name=uboot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
+part u-boot-env --source empty --part-name=${STM32MP_UENV_NAME} --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
 
 # Bootfs
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M

--- a/wic/sdcard-stm32mp157f-dk2-optee-1GB.wks.in
+++ b/wic/sdcard-stm32mp157f-dk2-optee-1GB.wks.in
@@ -24,7 +24,7 @@ part fip-a   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip
 part fip-b   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip-b --sourceparams="file=${DEPLOY_DIR_IMAGE}/fip/fip-stm32mp157f-dk2-optee.bin" --ondisk mmcblk --part-type 19d5df83-11b0-457b-be2c-7559c13142a5 --fixed-size 4096K --uuid 09c54952-d5bf-45af-acee-335303766fb3
 
 # U-BOOT env
-part u-boot-env --source empty --part-name=uboot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
+part u-boot-env --source empty --part-name=${STM32MP_UENV_NAME} --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
 
 # Bootfs
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M

--- a/wic/sdcard-stm32mp157f-dk2-optee-vendorfs-1GB.wks.in
+++ b/wic/sdcard-stm32mp157f-dk2-optee-vendorfs-1GB.wks.in
@@ -24,7 +24,7 @@ part fip-a   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip
 part fip-b   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip-b --sourceparams="file=${DEPLOY_DIR_IMAGE}/fip/fip-stm32mp157f-dk2-optee.bin" --ondisk mmcblk --part-type 19d5df83-11b0-457b-be2c-7559c13142a5 --fixed-size 4096K --uuid 09c54952-d5bf-45af-acee-335303766fb3
 
 # U-BOOT env
-part u-boot-env --source empty --part-name=uboot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
+part u-boot-env --source empty --part-name=${STM32MP_UENV_NAME} --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
 
 # Bootfs
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M

--- a/wic/sdcard-stm32mp157f-ev1-optee-1GB.wks.in
+++ b/wic/sdcard-stm32mp157f-ev1-optee-1GB.wks.in
@@ -24,7 +24,7 @@ part fip-a   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip
 part fip-b   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip-b --sourceparams="file=${DEPLOY_DIR_IMAGE}/fip/fip-stm32mp157f-ev1-optee.bin" --ondisk mmcblk --part-type 19d5df83-11b0-457b-be2c-7559c13142a5 --fixed-size 4096K --uuid 09c54952-d5bf-45af-acee-335303766fb3
 
 # U-BOOT env
-part u-boot-env --source empty --part-name=uboot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
+part u-boot-env --source empty --part-name=${STM32MP_UENV_NAME} --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
 
 # Bootfs
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M

--- a/wic/sdcard-stm32mp157f-ev1-optee-vendorfs-1GB.wks.in
+++ b/wic/sdcard-stm32mp157f-ev1-optee-vendorfs-1GB.wks.in
@@ -24,7 +24,7 @@ part fip-a   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip
 part fip-b   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip-b --sourceparams="file=${DEPLOY_DIR_IMAGE}/fip/fip-stm32mp157f-ev1-optee.bin" --ondisk mmcblk --part-type 19d5df83-11b0-457b-be2c-7559c13142a5 --fixed-size 4096K --uuid 09c54952-d5bf-45af-acee-335303766fb3
 
 # U-BOOT env
-part u-boot-env --source empty --part-name=uboot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
+part u-boot-env --source empty --part-name=${STM32MP_UENV_NAME} --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
 
 # Bootfs
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M


### PR DESCRIPTION
- Allow later variable assignment in extlinux.conf
- Insert name expected by u-boot (wic files)