### PR TITLE
CMSIS-SVD: update Git URL in recipe

### DIFF
--- a/recipes-devtools/cmsis-svd/cmsis-svd_git.bb
+++ b/recipes-devtools/cmsis-svd/cmsis-svd_git.bb
@@ -17,7 +17,7 @@ NO_GENERIC_LICENSE[svd-STMicro] = "data/STMicro/License.html"
 
 inherit pkgconfig autotools-brokensep gettext
 
-SRC_URI = "git://github.com/posborne/cmsis-svd.git;protocol=https;branch=master"
+SRC_URI = "git://github.com/cmsis-svd/cmsis-svd.git;protocol=https;branch=master"
 SRCREV = "f487b5ca7c132b8f09d11514c509372f83a6cb75"
 
 PV = "0.4+git${SRCPV}"


### PR DESCRIPTION
`WARNING: cmsis-svd-0.4+gitAUTOINC+f487b5ca7c-r0 do_fetch: Failed to fetch URL git://github.com/posborne/cmsis-svd.git;protocol=https;branch=master, attempting MIRRORS if available
ERROR: cmsis-svd-0.4+gitAUTOINC+f487b5ca7c-r0 do_fetch: Fetcher failure: Unable to find revision f487b5ca7c132b8f09d11514c509372f83a6cb75 in branch master even from upstream
ERROR: cmsis-svd-0.4+gitAUTOINC+f487b5ca7c-r0 do_fetch: Bitbake Fetcher Error: FetchError('Unable to fetch URL from any source.', 'git://github.com/posborne/cmsis-svd.git;protocol=https;branch=master')
ERROR: Logfile of failure stored in: ****/cmsis-svd/0.4+gitAUTOINC+f487b5ca7c-r0/temp/log.do_fetch.1171940
ERROR: Task (****/meta-st-stm32mp/recipes-devtools/cmsis-svd/cmsis-svd_git.bb:do_fetch) failed with exit code '1'`

Fetching raises an error message for cmsis-svd. The repo URL changed and the redirection is not working for the BB fetcher.