### PR TITLE
 cmsis-svd fetch uri no longer valid

### DIFF
--- a/recipes-devtools/cmsis-svd/cmsis-svd_git.bb
+++ b/recipes-devtools/cmsis-svd/cmsis-svd_git.bb
@@ -17,7 +17,7 @@ NO_GENERIC_LICENSE[svd-STMicro] = "data/STMicro/License.html"
 
 inherit pkgconfig autotools-brokensep gettext
 
-SRC_URI = "git://github.com/posborne/cmsis-svd.git;protocol=https;branch=main"
+SRC_URI = "gitsm://github.com/posborne/cmsis-svd.git;protocol=https;branch=main"
 SRCREV = "f487b5ca7c132b8f09d11514c509372f83a6cb75"
 
 PV = "0.4+git${SRCPV}"


### PR DESCRIPTION
Cloning/fetching the current link gives an error or timeout. Changing the protocol to gitsm fixes the issue.