### PR TITLE
gcc-source: Conditionally reference patch in SRC_URI depending on the machine

### DIFF
--- a/recipes-devtools/gcc/gcc-source_13.2.bbappend
+++ b/recipes-devtools/gcc/gcc-source_13.2.bbappend
@@ -1,4 +1,4 @@
 FILESEXTRAPATHS:prepend:stm32mpcommon := "${THISDIR}/gcc:"
-SRC_URI += " \
+SRC_URI:append:stm32mpcommon = " \
     file://0027-make-gcc-plugins-work-for-the-sdk.patch \
 "


### PR DESCRIPTION
* Without this addition, the build fails for the reason explained in https://docs.yoctoproject.org/next/migration-guides/migration-4.1.html#missing-local-files-in-src-uri-now-triggers-an-error

---
<details><summary>error message without the patch</summary>

```
ERROR: /home/lucas/yocto/yocto-scarthgap/build/../poky/meta/recipes-devtools/gcc/gcc-source_13.2.bb: Unable to get checksum for gcc-source-13.2.0 SRC_URI entry 0027-make-gcc-plugins-work-for-the-sdk.patch: file could not be found
The following paths were searched:
/home/lucas/yocto/yocto-scarthgap/build/../poky/meta/recipes-devtools/gcc/gcc/poky/0027-make-gcc-plugins-work-for-the-sdk.patch
/home/lucas/yocto/yocto-scarthgap/build/../poky/meta/recipes-devtools/gcc/gcc/backport/poky/0027-make-gcc-plugins-work-for-the-sdk.patch
/home/lucas/yocto/yocto-scarthgap/build/../poky/meta/recipes-devtools/gcc/gcc-13.2.0/poky/0027-make-gcc-plugins-work-for-the-sdk.patch
/home/lucas/yocto/yocto-scarthgap/build/../poky/meta/recipes-devtools/gcc/gcc/poky/0027-make-gcc-plugins-work-for-the-sdk.patch
/home/lucas/yocto/yocto-scarthgap/build/../poky/meta/recipes-devtools/gcc/files/poky/0027-make-gcc-plugins-work-for-the-sdk.patch
/home/lucas/yocto/yocto-scarthgap/build/../poky/meta/recipes-devtools/gcc/gcc/soboard/0027-make-gcc-plugins-work-for-the-sdk.patch
/home/lucas/yocto/yocto-scarthgap/build/../poky/meta/recipes-devtools/gcc/gcc/backport/soboard/0027-make-gcc-plugins-work-for-the-sdk.patch
/home/lucas/yocto/yocto-scarthgap/build/../poky/meta/recipes-devtools/gcc/gcc-13.2.0/soboard/0027-make-gcc-plugins-work-for-the-sdk.patch
/home/lucas/yocto/yocto-scarthgap/build/../poky/meta/recipes-devtools/gcc/gcc/soboard/0027-make-gcc-plugins-work-for-the-sdk.patch
/home/lucas/yocto/yocto-scarthgap/build/../poky/meta/recipes-devtools/gcc/files/soboard/0027-make-gcc-plugins-work-for-the-sdk.patch
/home/lucas/yocto/yocto-scarthgap/build/../poky/meta/recipes-devtools/gcc/gcc/armv7ve/0027-make-gcc-plugins-work-for-the-sdk.patch
/home/lucas/yocto/yocto-scarthgap/build/../poky/meta/recipes-devtools/gcc/gcc/backport/armv7ve/0027-make-gcc-plugins-work-for-the-sdk.patch
/home/lucas/yocto/yocto-scarthgap/build/../poky/meta/recipes-devtools/gcc/gcc-13.2.0/armv7ve/0027-make-gcc-plugins-work-for-the-sdk.patch
/home/lucas/yocto/yocto-scarthgap/build/../poky/meta/recipes-devtools/gcc/gcc/armv7ve/0027-make-gcc-plugins-work-for-the-sdk.patch
/home/lucas/yocto/yocto-scarthgap/build/../poky/meta/recipes-devtools/gcc/files/armv7ve/0027-make-gcc-plugins-work-for-the-sdk.patch
/home/lucas/yocto/yocto-scarthgap/build/../poky/meta/recipes-devtools/gcc/gcc/allarch/0027-make-gcc-plugins-work-for-the-sdk.patch
/home/lucas/yocto/yocto-scarthgap/build/../poky/meta/recipes-devtools/gcc/gcc/backport/allarch/0027-make-gcc-plugins-work-for-the-sdk.patch
/home/lucas/yocto/yocto-scarthgap/build/../poky/meta/recipes-devtools/gcc/gcc-13.2.0/allarch/0027-make-gcc-plugins-work-for-the-sdk.patch
/home/lucas/yocto/yocto-scarthgap/build/../poky/meta/recipes-devtools/gcc/gcc/allarch/0027-make-gcc-plugins-work-for-the-sdk.patch
/home/lucas/yocto/yocto-scarthgap/build/../poky/meta/recipes-devtools/gcc/files/allarch/0027-make-gcc-plugins-work-for-the-sdk.patch
/home/lucas/yocto/yocto-scarthgap/build/../poky/meta/recipes-devtools/gcc/gcc/0027-make-gcc-plugins-work-for-the-sdk.patch
/home/lucas/yocto/yocto-scarthgap/build/../poky/meta/recipes-devtools/gcc/gcc/backport/0027-make-gcc-plugins-work-for-the-sdk.patch
/home/lucas/yocto/yocto-scarthgap/build/../poky/meta/recipes-devtools/gcc/gcc-13.2.0/0027-make-gcc-plugins-work-for-the-sdk.patch
/home/lucas/yocto/yocto-scarthgap/build/../poky/meta/recipes-devtools/gcc/gcc/0027-make-gcc-plugins-work-for-the-sdk.patch
/home/lucas/yocto/yocto-scarthgap/build/../poky/meta/recipes-devtools/gcc/files/0027-make-gcc-plugins-work-for-the-sdk.patch
ERROR: Parsing halted due to errors, see error messages above
```

</details>