### PR TITLE
tf-a-tools: fix rot-key-pw to always NULL terminate

### DIFF
--- a/recipes-bsp/trusted-firmware-a/tf-a-tools.inc
+++ b/recipes-bsp/trusted-firmware-a/tf-a-tools.inc
@@ -3,6 +3,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/tf-a-tools:"
 SRC_URI:append = " \
     file://0001-FIX-GCC-tools-overwrite.patch \
     file://0001-tools-allow-to-use-a-root-key-password-from-command-.patch \
+    file://0002-tools-fix-rot-key-pw-to-always-NULL-terminate.patch \
     \
     file://create_st_fip_binary.sh \
     "

--- a/recipes-bsp/trusted-firmware-a/tf-a-tools/0002-tools-fix-rot-key-pw-to-always-NULL-terminate.patch
+++ b/recipes-bsp/trusted-firmware-a/tf-a-tools/0002-tools-fix-rot-key-pw-to-always-NULL-terminate.patch
@@ -1,0 +1,32 @@
+From 4e85dc73c6eda28dc5074fb29ab95bc29347b891 Mon Sep 17 00:00:00 2001
+From: Mike Wadsten <mike.wadsten@digi.com>
+Date: Mon, 15 Jul 2024 09:33:42 +0200
+Subject: [PATCH] tools: fix rot-key-pw to always NULL terminate
+
+The call to 'strncpy' does not NULL terminate the target
+string.
+Neither the allocation of memory for 'rot_key_pw', nor the
+call to strncpy had into account the NULL termination character
+which may lead to issues if the adjacent memory is not zero-init.
+
+Signed-off-by: Mike Wadsten <mike.wadsten@digi.com>
+Signed-off-by: Hector Palacios <hector.palacios@digi.com>
+---
+ tools/cert_create/src/main.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tools/cert_create/src/main.c b/tools/cert_create/src/main.c
+index 7a00279b3786..abbe1f3f9372 100644
+--- a/tools/cert_create/src/main.c
++++ b/tools/cert_create/src/main.c
+@@ -386,8 +386,8 @@ int main(int argc, char *argv[])
+ 			print_cert = 1;
+ 			break;
+ 		case 'r':
+-			rot_key_pw = malloc(sizeof(char) * strlen(optarg));
+-			strncpy(rot_key_pw, optarg, strlen(optarg));
++			rot_key_pw = malloc(sizeof(char) * strlen(optarg) + 1);
++			strncpy(rot_key_pw, optarg, strlen(optarg) + 1);
+ 			break;
+ 		case 's':
+ 			hash_alg = get_hash_alg(optarg);


### PR DESCRIPTION
The call to 'strncpy' does not NULL terminate the target string.
Neither the allocation of memory for 'rot_key_pw', nor the call to strncpy had into account the NULL termination character which may lead to issues if the adjacent memory is not zero-init.