### PR TITLE
sdcard-stm32mp157f-dk2-optee-vendorfs-1GB.wks.in: Fix

### DIFF
--- a/wic/sdcard-stm32mp157f-dk2-optee-vendorfs-1GB.wks.in
+++ b/wic/sdcard-stm32mp157f-dk2-optee-vendorfs-1GB.wks.in
@@ -27,12 +27,12 @@ part fip-b   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip
 part u-boot-env --source empty --part-name=uboot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
 
 # Bootfs
-part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M
+part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.bootfs.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M
 # Vendorfs
-part vendorfs --source rawcopy --sourceparams="file=st-image-vendorfs-${DISTRO}-${MACHINE}.ext4" --ondisk mmcblk --fstype=ext4 --label vendorfs --fixed-size 16M
+part vendorfs --source rawcopy --sourceparams="file=st-image-vendorfs-${DISTRO}-${MACHINE}.vendorfs.ext4" --ondisk mmcblk --fstype=ext4 --label vendorfs --fixed-size 16M
 # Rootfs
 part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size 772M --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
 # Userfs
-part usrfs --source rawcopy --sourceparams="file=st-image-userfs-${DISTRO}-${MACHINE}.ext4" --ondisk mmcblk --fstype=ext4 --label userfs --fixed-size 128M
+part usrfs --source rawcopy --sourceparams="file=st-image-userfs-${DISTRO}-${MACHINE}.userfs.ext4" --ondisk mmcblk --fstype=ext4 --label userfs --fixed-size 128M
 
 bootloader --ptable gpt


### PR DESCRIPTION
Fix filenames in sdcard-stm32mp157f-dk2-optee-vendorfs-1GB.wks.in to match the generated files for release Scarthgap.