### PR TITLE
LINUX-STM32MP: fix 'cpuidle-stm32' for CONFIG_CC_OPTIMIZE_FOR_SIZE'

### DIFF
--- a/recipes-kernel/linux/linux-stm32mp/5.15/5.15.145/0004-v5.15-stm32mp-r2.2-CPUIDLE-POWER.patch
+++ b/recipes-kernel/linux/linux-stm32mp/5.15/5.15.145/0004-v5.15-stm32mp-r2.2-CPUIDLE-POWER.patch
@@ -126,7 +126,7 @@ index 000000000000..2fef170d6877
 +	return index;
 +}
 +
-+static const struct of_device_id stm32_idle_state_match[] __initconst = {
++static const struct of_device_id stm32_idle_state_match[] = {
 +	{ .compatible = "arm,idle-state",
 +	  .data = stm32_enter_idle },
 +	{ },


### PR DESCRIPTION
```
WARNING: modpost: vmlinux.o(.exit.text+0x1b24): Section mismatch in reference from the function stm32_cpuidle_driver_exit() to the (unknown reference) .init.data:(unknown) | The function __exit stm32_cpuidle_driver_exit() references | a (unknown reference) __initdata (unknown).
| This is often seen when error handling in the exit function | uses functionality in the init path.
| The fix is often to remove the __initdata annotation of | (unknown) so it may be used outside an init section. |
| ERROR: modpost: Section mismatches detected.
---
```

---

Thanks @BernardPuel and @patrickdelaunay for fixing the upstream ST kernel 6.1 through my original PR #54

However I'd be interested to know if fixing the `kirkstone` faulty `.patch` from both these PR is possible,  
because one year later and being updated to all latest Yocto `4.0.20` layers + STM32MP `kirkstone`,  
and ST kernel current version 5.15.145, this build fix still needs to be kept and maintained locally.

I understand the newest version versus maintenance branches priorities, and isolation between internal Gerrit and PRs,  
but the `kirkstone` branch being LTS and required by some STM32MP1 SOM providers or projects aligned on this LTS,
it should allow minor build fixes as these that affect only the branch (and avoid others to hit & fix these locally again).

Thanks !