### PR TITLE
MACHINE: fix 'TF_A_MTD_START_OFFSET_NOR' with/without 'fw-update' feature [kirkstone, mickledore, scarthgap]

### DIFF
--- a/conf/machine/include/st-machine-common-stm32mp.inc
+++ b/conf/machine/include/st-machine-common-stm32mp.inc
@@ -601,7 +601,7 @@ TF_A_METADATA_BINARY ?= "metadata.bin"
 
 # Configure the default MTD_START_OFFSET
 TF_A_MTD_START_OFFSET_NAND    ?= "0x00200000"
-TF_A_MTD_START_OFFSET_NOR     ?= "${@bb.utils.contains('MACHINE_FEATURES', 'fw-update', '0x00080000', '0x00100000', d)}"
+TF_A_MTD_START_OFFSET_NOR     ?= "${@bb.utils.contains('MACHINE_FEATURES', 'fw-update', '0x00100000', '0x00080000', d)}"
 TF_A_MTD_START_OFFSET_SPINAND ?= "0x00200000"
 
 ST_TF_A_DEBUG_TRACE ?= "${@bb.utils.contains('ST_DEBUG_TRACE', '1', '1', '0', d)}"


### PR DESCRIPTION
**Issue:**
  - Before commit 71ade1b, 'TF_A_MTD_START_OFFSET_NOR' was '0x00080000'
  - After 'fwupdate support' was added, default value became '0x00100000', and 'fw-update' alternative value was the original '0x00080000' value

**Context:**
  - As visible in file 'FlashLayout_nor-sdcard_stm32mp157c-ev1_sample.tsv', with 'fw-update' enabled, the 'fip' primary partition offset on QSPI NOR moved from '0x00080000' to '0x00100000'

**Origin:**
  - Last year, without 'fw-update' enabled, I still had to create 'metadata1/2'
  - After commit 4bea958 fixed 'TF_A_ENABLE_METADATA', the generated layout is back to expected normal value, however 'TF_A_MTD_START_OFFSET_NOR' breaks, hence both issues revealed each other's issues

**Workaround:**
  - TF_A_MTD_START_OFFSET_NOR = "0x00080000"