### PR TITLE
CONF: MACHINE: use weak assignment for PREFERRED_PROVIDER

### DIFF
--- a/conf/machine/include/gpu_vivante.inc
+++ b/conf/machine/include/gpu_vivante.inc
@@ -39,10 +39,10 @@ def get_gpu_vivante_handler(d):
 
 GPU_USERLAND_LIBRARIES_INSTALL = "${@get_gpu_vivante_handler(d)}"
 
-PREFERRED_PROVIDER_virtual/egl = "${@get_gpu_vivante_handler(d)}"
-PREFERRED_PROVIDER_virtual/libgles1 = "${@get_gpu_vivante_handler(d)}"
-PREFERRED_PROVIDER_virtual/libgles2 = "${@get_gpu_vivante_handler(d)}"
-PREFERRED_PROVIDER_virtual/libgles3 = "${@get_gpu_vivante_handler(d)}"
-PREFERRED_PROVIDER_virtual/libgbm = "${@get_gpu_vivante_handler(d)}"
-PREFERRED_PROVIDER_virtual/mesa = "${@bb.utils.contains('PREFERRED_PROVIDER_virtual/egl','mesa','mesa','mesa-gl',d)}"
-PREFERRED_PROVIDER_virtual/libgl = "${@bb.utils.contains('PREFERRED_PROVIDER_virtual/egl','mesa','mesa','mesa-gl',d)}"
+PREFERRED_PROVIDER_virtual/egl ??= "${@get_gpu_vivante_handler(d)}"
+PREFERRED_PROVIDER_virtual/libgles1 ??= "${@get_gpu_vivante_handler(d)}"
+PREFERRED_PROVIDER_virtual/libgles2 ??= "${@get_gpu_vivante_handler(d)}"
+PREFERRED_PROVIDER_virtual/libgles3 ??= "${@get_gpu_vivante_handler(d)}"
+PREFERRED_PROVIDER_virtual/libgbm ??= "${@get_gpu_vivante_handler(d)}"
+PREFERRED_PROVIDER_virtual/mesa ??= "${@bb.utils.contains('PREFERRED_PROVIDER_virtual/egl','mesa','mesa','mesa-gl',d)}"
+PREFERRED_PROVIDER_virtual/libgl ??= "${@bb.utils.contains('PREFERRED_PROVIDER_virtual/egl','mesa','mesa','mesa-gl',d)}"

--- a/conf/machine/include/st-machine-common-stm32mp.inc
+++ b/conf/machine/include/st-machine-common-stm32mp.inc
@@ -668,7 +668,7 @@ UBOOT_MTDPART_CHECK ?= "\
     ${@bb.utils.contains('BOOTDEVICE_LABELS', 'spinand-2-128', 'CONFIG_MTDPARTS_SPINAND0_BOOT=${UBOOT_MTDPART_SPINAND_BOOT}', '', d)} \
     "
 
-PREFERRED_PROVIDER_u-boot-fw-utils:stm32mp1common = "libubootenv"
+PREFERRED_PROVIDER_u-boot-fw-utils:stm32mp1common ??= "libubootenv"
 
 MACHINE_EXTRA_RRECOMMENDS:append:stm32mp1common = " \
     u-boot-fw-config-stm32mp \
@@ -755,7 +755,7 @@ ELF_DEBUG_ENABLE = "1"
 # =========================================================================
 # sysdig
 # =========================================================================
-PREFERRED_PROVIDER_sysdig = "sysdig-stm32mp"
+PREFERRED_PROVIDER_sysdig ??= "sysdig-stm32mp"
 
 # =========================================================================
 # M4 copro

--- a/conf/machine/include/st-machine-providers-stm32mp.inc
+++ b/conf/machine/include/st-machine-providers-stm32mp.inc
@@ -1,20 +1,20 @@
 # =========================================================================
 # Kernel
 # =========================================================================
-PREFERRED_PROVIDER_virtual/kernel = "linux-stm32mp"
+PREFERRED_PROVIDER_virtual/kernel ??= "linux-stm32mp"
 
 # =========================================================================
 # u-boot
 # =========================================================================
-PREFERRED_PROVIDER_virtual/bootloader = "u-boot-stm32mp"
-PREFERRED_PROVIDER_u-boot = "u-boot-stm32mp"
+PREFERRED_PROVIDER_virtual/bootloader ??= "u-boot-stm32mp"
+PREFERRED_PROVIDER_u-boot ??= "u-boot-stm32mp"
 
 # =========================================================================
 # trusted-firmware-a
 # =========================================================================
-PREFERRED_PROVIDER_virtual/trusted-firmware-a = "tf-a-stm32mp"
+PREFERRED_PROVIDER_virtual/trusted-firmware-a ??= "tf-a-stm32mp"
 
 # =========================================================================
 # optee-os
 # =========================================================================
-PREFERRED_PROVIDER_virtual-optee-os = "optee-os-stm32mp"
+PREFERRED_PROVIDER_virtual-optee-os ??= "optee-os-stm32mp"


### PR DESCRIPTION
Using the ??= operator allows to override PREFERRED_PROVIDER in local.conf easily.

See the commit message for more details.