### PR TITLE
Add missing LIC_FILES_CHKSUM

### DIFF
--- a/recipes-devtools/optee-sdk/optee-sdk_1.0.0.bb
+++ b/recipes-devtools/optee-sdk/optee-sdk_1.0.0.bb
@@ -1,6 +1,7 @@
 SUMMARY = "TA development kit built from optee_os, needed to build OP-TEE TAs"
 
 LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
 SRC_URI:append:class-nativesdk = " file://environment.d-optee-sdk.sh"
 


### PR DESCRIPTION
Building meta-toolchain fails without LIC_FILES_CHKSUM present.

The variable is required, as specified in Yocto documentation https://docs.yoctoproject.org/ref-manual/variables.html#term-LIC_FILES_CHKSUM

> This variable must be defined for all recipes (unless [LICENSE](https://docs.yoctoproject.org/ref-manual/variables.html#term-LICENSE) is set to “CLOSED”).