### PR TITLE
openssl: remove redundant .bbappend

### DIFF
--- a/recipes-connectivity/openssl/openssl_%.bbappend
+++ b/recipes-connectivity/openssl/openssl_%.bbappend
@@ -1,5 +1,0 @@
-FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
-
-do_install:append:class-nativesdk() {
-    echo "export OPENSSL_MODULES=\"\$OECORE_NATIVE_SYSROOT/usr/lib/ossl-modules/\"" >> ${D}${SDKPATHNATIVE}/environment-setup.d/openssl.sh
-}


### PR DESCRIPTION
The FILESEXTRAPATHS setting has never had any function as there has never been any replacement or additional files shipped together with this .bbappend.

The do_install snippet is redundant since oe-core commit d6b15d1e70b9, and results in the openssl.sh snippet ending up containing

$ cat ./x86_64-oesdk-linux/environment-setup.d/openssl.sh export OPENSSL_CONF="$OECORE_NATIVE_SYSROOT/usr/lib/ssl-3/openssl.cnf" export SSL_CERT_DIR="$OECORE_NATIVE_SYSROOT/usr/lib/ssl-3/certs" export SSL_CERT_FILE="$OECORE_NATIVE_SYSROOT/usr/lib/ssl-3/certs/ca-certificates.crt" export OPENSSL_MODULES="$OECORE_NATIVE_SYSROOT/usr/lib/ossl-modules/" export OPENSSL_ENGINES="$OECORE_NATIVE_SYSROOT/usr/lib/engines-3" export OPENSSL_MODULES="$OECORE_NATIVE_SYSROOT/usr/lib/ossl-modules/"