### PR TITLE
fix image manifest filename

### DIFF
--- a/classes/st-partitions-image.bbclass
+++ b/classes/st-partitions-image.bbclass
@@ -155,6 +155,7 @@ python image_rootfs_image_clean_task(){
 
     deploy_image_dir = d.expand("${DEPLOY_DIR}")
     machine = d.expand("${MACHINE}")
+    image_machine_suffix = d.getVar('IMAGE_MACHINE_SUFFIX') or ""
     distro = d.expand("${DISTRO}")
     img_rootfs = d.getVar('IMAGE_ROOTFS')
     partitionsconfigflags = d.getVarFlags('PARTITIONS_IMAGES')
@@ -197,7 +198,7 @@ python image_rootfs_image_clean_task(){
 
             # Manifest file of the partition to check packages are in that partition
             manif_file = os.path.join(deploy_image_dir, "images", machine,
-                         _img_partition + "-" + distro + "-" + machine + ".manifest")
+                         _img_partition + "-" + distro + image_machine_suffix + ".manifest")
             try:
                 manifest_content = open(manif_file, "r")
                 contents = manifest_content.read().splitlines()


### PR DESCRIPTION
since mickledore the suffix is not always the MACHINE variable. It can be set with another variable IMAGE_MACHINE_SUFFIX, which defaults to "-${MACHINE}".

this can be used to cleanup the deploy folder (since the machine information is already part of the folder structure leading to the images).

without this change building using the st-partitions-image.bbclass will fail