### PR TITLE
chanege openocd's depends src_url to review.openocd.org

### DIFF
--- a/recipes-devtools/openocd/openocd-stm32mp.inc
+++ b/recipes-devtools/openocd/openocd-stm32mp.inc
@@ -7,9 +7,9 @@ CVE_PRODUCT = "openocd:open_on-chip_debugger"
 inherit pkgconfig autotools-brokensep gettext
 
 SRC_URI:append = " \
-    git://git.savannah.nongnu.org/git/git2cl.git;protocol=https;;destsuffix=git/tools/git2cl;nobranch=1;name=git2cl         \
-    git://github.com/msteveb/jimtcl.git;protocol=https;destsuffix=git/jimtcl;nobranch=1;name=jimtcl                         \
-    git://gitlab.zapb.de/libjaylink/libjaylink.git;protocol=https;destsuffix=git/src/jtag/drivers/libjaylink;nobranch=1;name=libjaylink \
+    git://review.openocd.org/git/git2cl.git;protocol=https;;destsuffix=git/tools/git2cl;nobranch=1;name=git2cl         \
+    git://review.openocd.org/jimtcl.git;protocol=https;destsuffix=git/jimtcl;nobranch=1;name=jimtcl                         \
+    git://review.openocd.org/libjaylink.git;protocol=https;destsuffix=git/src/jtag/drivers/libjaylink;nobranch=1;name=libjaylink \
     "
 
 SRCREV_git2cl = "8373c9f74993e218a08819cbcdbab3f3564bbeba"


### PR DESCRIPTION
The third-party code source (git.savannah.nongnu.org/git2cl) doesn't seem to be working properly. Since the OpenOCD official website provides these code mirrors, I think it's a suitable choice to use the official mirror.