### PR TITLE
wic: use dynamic rootfs maximum size variable

### DIFF
--- a/wic/sdcard-stm32mp135f-dk-optee-1GB.wks.in
+++ b/wic/sdcard-stm32mp135f-dk-optee-1GB.wks.in
@@ -29,7 +29,7 @@ part u-boot-env --source empty --part-name=uboot-env --ondisk mmcblk --part-type
 # Bootfs
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.bootfs.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M
 # Rootfs
-part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size 783M --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
+part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size ${IMAGE_ROOTFS_SIZE} --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
 # Userfs
 part usrfs --source rawcopy --sourceparams="file=st-image-userfs-${DISTRO}-${MACHINE}.userfs.ext4" --ondisk mmcblk --fstype=ext4 --label userfs --fixed-size 128M
 

--- a/wic/sdcard-stm32mp135f-dk-optee-vendorfs-1GB.wks.in
+++ b/wic/sdcard-stm32mp135f-dk-optee-vendorfs-1GB.wks.in
@@ -31,7 +31,7 @@ part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MA
 # Vendorfs
 part vendorfs --source rawcopy --sourceparams="file=st-image-vendorfs-${DISTRO}-${MACHINE}.vendorfs.ext4" --ondisk mmcblk --fstype=ext4 --label vendorfs --fixed-size 16M
 # Rootfs
-part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size 772M --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
+part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size ${IMAGE_ROOTFS_SIZE} --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
 # Userfs
 part usrfs --source rawcopy --sourceparams="file=st-image-userfs-${DISTRO}-${MACHINE}.userfs.ext4" --ondisk mmcblk --fstype=ext4 --label userfs --fixed-size 128M
 

--- a/wic/sdcard-stm32mp157f-dk2-optee-1GB.wks.in
+++ b/wic/sdcard-stm32mp157f-dk2-optee-1GB.wks.in
@@ -29,7 +29,7 @@ part u-boot-env --source empty --part-name=uboot-env --ondisk mmcblk --part-type
 # Bootfs
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.bootfs.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M
 # Rootfs
-part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size 783M --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
+part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size ${IMAGE_ROOTFS_SIZE} --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
 # Userfs
 part usrfs --source rawcopy --sourceparams="file=st-image-userfs-${DISTRO}-${MACHINE}.userfs.ext4" --ondisk mmcblk --fstype=ext4 --label userfs --fixed-size 128M
 

--- a/wic/sdcard-stm32mp157f-dk2-optee-vendorfs-1GB.wks.in
+++ b/wic/sdcard-stm32mp157f-dk2-optee-vendorfs-1GB.wks.in
@@ -31,7 +31,7 @@ part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MA
 # Vendorfs
 part vendorfs --source rawcopy --sourceparams="file=st-image-vendorfs-${DISTRO}-${MACHINE}.vendorfs.ext4" --ondisk mmcblk --fstype=ext4 --label vendorfs --fixed-size 16M
 # Rootfs
-part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size 772M --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
+part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size ${IMAGE_ROOTFS_SIZE} --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
 # Userfs
 part usrfs --source rawcopy --sourceparams="file=st-image-userfs-${DISTRO}-${MACHINE}.userfs.ext4" --ondisk mmcblk --fstype=ext4 --label userfs --fixed-size 128M
 

--- a/wic/sdcard-stm32mp157f-dk2-opteemin-1GB.wks.in
+++ b/wic/sdcard-stm32mp157f-dk2-opteemin-1GB.wks.in
@@ -29,7 +29,7 @@ part u-boot-env --source empty --part-name=uboot-env --ondisk mmcblk --part-type
 # Bootfs
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.bootfs.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M
 # Rootfs
-part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size 783M --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
+part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size ${IMAGE_ROOTFS_SIZE} --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
 # Userfs
 part usrfs --source rawcopy --sourceparams="file=st-image-userfs-${DISTRO}-${MACHINE}.userfs.ext4" --ondisk mmcblk --fstype=ext4 --label userfs --fixed-size 128M
 

--- a/wic/sdcard-stm32mp157f-dk2-opteemin-vendorfs-1GB.wks.in
+++ b/wic/sdcard-stm32mp157f-dk2-opteemin-vendorfs-1GB.wks.in
@@ -31,7 +31,7 @@ part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MA
 # Vendorfs
 part vendorfs --source rawcopy --sourceparams="file=st-image-vendorfs-${DISTRO}-${MACHINE}.vendorfs.ext4" --ondisk mmcblk --fstype=ext4 --label vendorfs --fixed-size 16M
 # Rootfs
-part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size 772M --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
+part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size ${IMAGE_ROOTFS_SIZE} --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
 # Userfs
 part usrfs --source rawcopy --sourceparams="file=st-image-userfs-${DISTRO}-${MACHINE}.userfs.ext4" --ondisk mmcblk --fstype=ext4 --label userfs --fixed-size 128M
 

--- a/wic/sdcard-stm32mp157f-ev1-optee-1GB.wks.in
+++ b/wic/sdcard-stm32mp157f-ev1-optee-1GB.wks.in
@@ -29,7 +29,7 @@ part u-boot-env --source empty --part-name=uboot-env --ondisk mmcblk --part-type
 # Bootfs
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.bootfs.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M
 # Rootfs
-part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size 783M --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
+part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size ${IMAGE_ROOTFS_SIZE} --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
 # Userfs
 part usrfs --source rawcopy --sourceparams="file=st-image-userfs-${DISTRO}-${MACHINE}.userfs.ext4" --ondisk mmcblk --fstype=ext4 --label userfs --fixed-size 128M
 

--- a/wic/sdcard-stm32mp157f-ev1-optee-vendorfs-1GB.wks.in
+++ b/wic/sdcard-stm32mp157f-ev1-optee-vendorfs-1GB.wks.in
@@ -31,7 +31,7 @@ part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MA
 # Vendorfs
 part vendorfs --source rawcopy --sourceparams="file=st-image-vendorfs-${DISTRO}-${MACHINE}.vendorfs.ext4" --ondisk mmcblk --fstype=ext4 --label vendorfs --fixed-size 16M
 # Rootfs
-part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size 772M --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
+part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size ${IMAGE_ROOTFS_SIZE} --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
 # Userfs
 part usrfs --source rawcopy --sourceparams="file=st-image-userfs-${DISTRO}-${MACHINE}.userfs.ext4" --ondisk mmcblk --fstype=ext4 --label userfs --fixed-size 128M
 

--- a/wic/sdcard-stm32mp157f-ev1-opteemin-1GB.wks.in
+++ b/wic/sdcard-stm32mp157f-ev1-opteemin-1GB.wks.in
@@ -29,7 +29,7 @@ part u-boot-env --source empty --part-name=uboot-env --ondisk mmcblk --part-type
 # Bootfs
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.bootfs.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M
 # Rootfs
-part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size 783M --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
+part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size ${IMAGE_ROOTFS_SIZE} --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
 # Userfs
 part usrfs --source rawcopy --sourceparams="file=st-image-userfs-${DISTRO}-${MACHINE}.userfs.ext4" --ondisk mmcblk --fstype=ext4 --label userfs --fixed-size 128M
 

--- a/wic/sdcard-stm32mp157f-ev1-opteemin-vendorfs-1GB.wks.in
+++ b/wic/sdcard-stm32mp157f-ev1-opteemin-vendorfs-1GB.wks.in
@@ -31,7 +31,7 @@ part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MA
 # Vendorfs
 part vendorfs --source rawcopy --sourceparams="file=st-image-vendorfs-${DISTRO}-${MACHINE}.vendorfs.ext4" --ondisk mmcblk --fstype=ext4 --label vendorfs --fixed-size 16M
 # Rootfs
-part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size 772M --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
+part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size ${IMAGE_ROOTFS_SIZE} --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
 # Userfs
 part usrfs --source rawcopy --sourceparams="file=st-image-userfs-${DISTRO}-${MACHINE}.userfs.ext4" --ondisk mmcblk --fstype=ext4 --label userfs --fixed-size 128M
 

--- a/wic/sdcard-stm32mp215f-dk-optee-2GB.wks.in
+++ b/wic/sdcard-stm32mp215f-dk-optee-2GB.wks.in
@@ -29,7 +29,7 @@ part u-boot-env --source empty --part-name=uboot-env --ondisk mmcblk --part-type
 # Bootfs
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.bootfs.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M
 # Rootfs
-part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size 1712M --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
+part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size ${IMAGE_ROOTFS_SIZE} --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
 # Userfs
 part usrfs --source rawcopy --sourceparams="file=st-image-userfs-${DISTRO}-${MACHINE}.userfs.ext4" --ondisk mmcblk --fstype=ext4 --label userfs --fixed-size 256M
 

--- a/wic/sdcard-stm32mp215f-dk-optee-vendorfs-2GB.wks.in
+++ b/wic/sdcard-stm32mp215f-dk-optee-vendorfs-2GB.wks.in
@@ -31,7 +31,7 @@ part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MA
 # Vendorfs
 part vendorfs --source rawcopy --sourceparams="file=st-image-vendorfs-${DISTRO}-${MACHINE}.vendorfs.ext4" --ondisk mmcblk --fstype=ext4 --label vendorfs --fixed-size 250M
 # Rootfs
-part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size 1512M --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
+part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size ${IMAGE_ROOTFS_SIZE} --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
 # Userfs
 part usrfs --source rawcopy --sourceparams="file=st-image-userfs-${DISTRO}-${MACHINE}.userfs.ext4" --ondisk mmcblk --fstype=ext4 --label userfs --fixed-size 200M
 

--- a/wic/sdcard-stm32mp235f-dk-optee-2GB.wks.in
+++ b/wic/sdcard-stm32mp235f-dk-optee-2GB.wks.in
@@ -29,7 +29,7 @@ part u-boot-env --source empty --part-name=uboot-env --ondisk mmcblk --part-type
 # Bootfs
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.bootfs.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M
 # Rootfs
-part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size 1712M --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
+part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size ${IMAGE_ROOTFS_SIZE} --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
 # Userfs
 part usrfs --source rawcopy --sourceparams="file=st-image-userfs-${DISTRO}-${MACHINE}.userfs.ext4" --ondisk mmcblk --fstype=ext4 --label userfs --fixed-size 256M
 

--- a/wic/sdcard-stm32mp235f-dk-optee-vendorfs-2GB.wks.in
+++ b/wic/sdcard-stm32mp235f-dk-optee-vendorfs-2GB.wks.in
@@ -31,7 +31,7 @@ part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MA
 # Vendorfs
 part vendorfs --source rawcopy --sourceparams="file=st-image-vendorfs-${DISTRO}-${MACHINE}.vendorfs.ext4" --ondisk mmcblk --fstype=ext4 --label vendorfs --fixed-size 250M
 # Rootfs
-part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size 1512M --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
+part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size ${IMAGE_ROOTFS_SIZE} --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
 # Userfs
 part usrfs --source rawcopy --sourceparams="file=st-image-userfs-${DISTRO}-${MACHINE}.userfs.ext4" --ondisk mmcblk --fstype=ext4 --label userfs --fixed-size 200M
 

--- a/wic/sdcard-stm32mp257f-dk-optee-2GB.wks.in
+++ b/wic/sdcard-stm32mp257f-dk-optee-2GB.wks.in
@@ -29,7 +29,7 @@ part u-boot-env --source empty --part-name=uboot-env --ondisk mmcblk --part-type
 # Bootfs
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.bootfs.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M
 # Rootfs
-part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size 1712M --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
+part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size ${IMAGE_ROOTFS_SIZE} --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
 # Userfs
 part usrfs --source rawcopy --sourceparams="file=st-image-userfs-${DISTRO}-${MACHINE}.userfs.ext4" --ondisk mmcblk --fstype=ext4 --label userfs --fixed-size 256M
 

--- a/wic/sdcard-stm32mp257f-dk-optee-vendorfs-2GB.wks.in
+++ b/wic/sdcard-stm32mp257f-dk-optee-vendorfs-2GB.wks.in
@@ -31,7 +31,7 @@ part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MA
 # Vendorfs
 part vendorfs --source rawcopy --sourceparams="file=st-image-vendorfs-${DISTRO}-${MACHINE}.vendorfs.ext4" --ondisk mmcblk --fstype=ext4 --label vendorfs --fixed-size 250M
 # Rootfs
-part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size 1512M --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
+part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size ${IMAGE_ROOTFS_SIZE} --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
 # Userfs
 part usrfs --source rawcopy --sourceparams="file=st-image-userfs-${DISTRO}-${MACHINE}.userfs.ext4" --ondisk mmcblk --fstype=ext4 --label userfs --fixed-size 200M
 

--- a/wic/sdcard-stm32mp257f-ev1-optee-2GB.wks.in
+++ b/wic/sdcard-stm32mp257f-ev1-optee-2GB.wks.in
@@ -29,7 +29,7 @@ part u-boot-env --source empty --part-name=uboot-env --ondisk mmcblk --part-type
 # Bootfs
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.bootfs.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M
 # Rootfs
-part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size 1712M --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
+part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size ${IMAGE_ROOTFS_SIZE} --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
 # Userfs
 part usrfs --source rawcopy --sourceparams="file=st-image-userfs-${DISTRO}-${MACHINE}.userfs.ext4" --ondisk mmcblk --fstype=ext4 --label userfs --fixed-size 256M
 

--- a/wic/sdcard-stm32mp257f-ev1-optee-vendorfs-2GB.wks.in
+++ b/wic/sdcard-stm32mp257f-ev1-optee-vendorfs-2GB.wks.in
@@ -31,7 +31,7 @@ part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MA
 # Vendorfs
 part vendorfs --source rawcopy --sourceparams="file=st-image-vendorfs-${DISTRO}-${MACHINE}.vendorfs.ext4" --ondisk mmcblk --fstype=ext4 --label vendorfs --fixed-size 250M
 # Rootfs
-part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size 1512M --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
+part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --fixed-size ${IMAGE_ROOTFS_SIZE} --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
 # Userfs
 part usrfs --source rawcopy --sourceparams="file=st-image-userfs-${DISTRO}-${MACHINE}.userfs.ext4" --ondisk mmcblk --fstype=ext4 --label userfs --fixed-size 200M
 


### PR DESCRIPTION
Replace the fixed size of the root filesystem partition in WKS files with the variable ${IMAGE_ROOTFS_MAXSIZE}. This change allows for more flexible configuration of the root filesystem size, improving adaptability for different image builds.