### PR TITLE
Fix wic circular dependencies

### DIFF
--- a/recipes-st/images/st-image-bootfs.bb
+++ b/recipes-st/images/st-image-bootfs.bb
@@ -22,3 +22,5 @@ INITRD_PACKAGE ?= ""
 PACKAGE_INSTALL += " \
     ${@bb.utils.contains('MACHINE_FEATURES', 'initrd', '${INITRD_PACKAGE}', '', d)} \
 "
+
+IMAGE_FSTYPES = "ext4"

--- a/recipes-st/images/st-image-userfs.bb
+++ b/recipes-st/images/st-image-userfs.bb
@@ -19,3 +19,5 @@ PACKAGE_INSTALL += " \
 PACKAGE_INSTALL += " \
     packagegroup-st-demo \
     "
+
+IMAGE_FSTYPES = "ext4"


### PR DESCRIPTION
Force the image type for the bootfs and the userfs images, otherwise, the following errors will occur when a WIC image is built:

```
ERROR: build/../layers/meta-st-stm32mp/recipes-st/images/st-image-bootfs.bb:                                                                                                                                                                                                                                           
[PARTITIONS_IMAGES] Circular dependency issue found for partition image build!                                                                                                                                                                                                                                               
[PARTITIONS_IMAGES] Please make sure to add all related wic image type(s) to                                                                                                                                                                                                                                                 
[PARTITIONS_IMAGES] WKS_IMAGE_FSTYPE var to properly remove them for partition                                                                                                                                                                                                                                               
[PARTITIONS_IMAGES] image build.                                                                                                                                                                                                                                                                                             
[PARTITIONS_IMAGES] IMAGE_FSTYPES    : wic.xz wic.bmap ext4                                                                                                                                                                                                                                                                  
[PARTITIONS_IMAGES] WKS_IMAGE_FSTYPES:                                                                                                                                                                                                                                                                  
ERROR: build/../layers/meta-st-stm32mp/recipes-st/images/st-image-userfs.bb:                                                                                                                                                                                                                                                 
[PARTITIONS_IMAGES] Circular dependency issue found for partition image build!                                                                                                                                                                                                                                               
[PARTITIONS_IMAGES] Please make sure to add all related wic image type(s) to                                                                                                                                                                                                                                                 
[PARTITIONS_IMAGES] WKS_IMAGE_FSTYPE var to properly remove them for partition                                                                                                                                                                                                                                               
[PARTITIONS_IMAGES] image build.                                                                                                                                                                                                                                                                                             
[PARTITIONS_IMAGES] IMAGE_FSTYPES    : wic.xz wic.bmap ext4                                                                                                                                                                                                                                                                  
[PARTITIONS_IMAGES] WKS_IMAGE_FSTYPES:                                                                                                                                                                                                                                                                                       
ERROR: Parsing halted due to errors, see error messages above
```