### PR TITLE
WIC: use correct name for u-boot-env partition

### DIFF
--- a/wic/sdcard-stm32mp135f-dk-optee-example.wks.in
+++ b/wic/sdcard-stm32mp135f-dk-optee-example.wks.in
@@ -25,7 +25,7 @@ part fip-a   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip
 part fip-b   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip-b --sourceparams="file=${DEPLOY_DIR_IMAGE}/fip/fip-stm32mp135f-dk-optee-sdcard.bin" --ondisk mmcblk --part-type 19d5df83-11b0-457b-be2c-7559c13142a5 --fixed-size 4096K --uuid 09c54952-d5bf-45af-acee-335303766fb3
 
 # U-BOOT env
-part u-boot-env --source empty --part-name=uboot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
+part u-boot-env --source empty --part-name=u-boot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
 
 # Bootfs
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.bootfs.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M

--- a/wic/sdcard-stm32mp135f-dk-optee-vendorfs-example.wks.in
+++ b/wic/sdcard-stm32mp135f-dk-optee-vendorfs-example.wks.in
@@ -25,7 +25,7 @@ part fip-a   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip
 part fip-b   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip-b --sourceparams="file=${DEPLOY_DIR_IMAGE}/fip/fip-stm32mp135f-dk-optee-sdcard.bin" --ondisk mmcblk --part-type 19d5df83-11b0-457b-be2c-7559c13142a5 --fixed-size 4096K --uuid 09c54952-d5bf-45af-acee-335303766fb3
 
 # U-BOOT env
-part u-boot-env --source empty --part-name=uboot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
+part u-boot-env --source empty --part-name=u-boot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
 
 # Bootfs
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.bootfs.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M

--- a/wic/sdcard-stm32mp157f-dk2-optee-example.wks.in
+++ b/wic/sdcard-stm32mp157f-dk2-optee-example.wks.in
@@ -25,7 +25,7 @@ part fip-a   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip
 part fip-b   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip-b --sourceparams="file=${DEPLOY_DIR_IMAGE}/fip/fip-stm32mp157f-dk2-optee-sdcard.bin" --ondisk mmcblk --part-type 19d5df83-11b0-457b-be2c-7559c13142a5 --fixed-size 4096K --uuid 09c54952-d5bf-45af-acee-335303766fb3
 
 # U-BOOT env
-part u-boot-env --source empty --part-name=uboot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
+part u-boot-env --source empty --part-name=u-boot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
 
 # Bootfs
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.bootfs.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M

--- a/wic/sdcard-stm32mp157f-dk2-optee-vendorfs-example.wks.in
+++ b/wic/sdcard-stm32mp157f-dk2-optee-vendorfs-example.wks.in
@@ -25,7 +25,7 @@ part fip-a   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip
 part fip-b   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip-b --sourceparams="file=${DEPLOY_DIR_IMAGE}/fip/fip-stm32mp157f-dk2-optee-sdcard.bin" --ondisk mmcblk --part-type 19d5df83-11b0-457b-be2c-7559c13142a5 --fixed-size 4096K --uuid 09c54952-d5bf-45af-acee-335303766fb3
 
 # U-BOOT env
-part u-boot-env --source empty --part-name=uboot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
+part u-boot-env --source empty --part-name=u-boot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
 
 # Bootfs
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.bootfs.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M

--- a/wic/sdcard-stm32mp157f-dk2-opteemin-example.wks.in
+++ b/wic/sdcard-stm32mp157f-dk2-opteemin-example.wks.in
@@ -25,7 +25,7 @@ part fip-a   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip
 part fip-b   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip-b --sourceparams="file=${DEPLOY_DIR_IMAGE}/fip/fip-stm32mp157f-dk2-opteemin-sdcard.bin" --ondisk mmcblk --part-type 19d5df83-11b0-457b-be2c-7559c13142a5 --fixed-size 4096K --uuid 09c54952-d5bf-45af-acee-335303766fb3
 
 # U-BOOT env
-part u-boot-env --source empty --part-name=uboot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
+part u-boot-env --source empty --part-name=u-boot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
 
 # Bootfs
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.bootfs.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M

--- a/wic/sdcard-stm32mp157f-dk2-opteemin-vendorfs-example.wks.in
+++ b/wic/sdcard-stm32mp157f-dk2-opteemin-vendorfs-example.wks.in
@@ -25,7 +25,7 @@ part fip-a   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip
 part fip-b   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip-b --sourceparams="file=${DEPLOY_DIR_IMAGE}/fip/fip-stm32mp157f-dk2-opteemin-sdcard.bin" --ondisk mmcblk --part-type 19d5df83-11b0-457b-be2c-7559c13142a5 --fixed-size 4096K --uuid 09c54952-d5bf-45af-acee-335303766fb3
 
 # U-BOOT env
-part u-boot-env --source empty --part-name=uboot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
+part u-boot-env --source empty --part-name=u-boot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
 
 # Bootfs
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.bootfs.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M

--- a/wic/sdcard-stm32mp157f-ev1-optee-example.wks.in
+++ b/wic/sdcard-stm32mp157f-ev1-optee-example.wks.in
@@ -25,7 +25,7 @@ part fip-a   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip
 part fip-b   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip-b --sourceparams="file=${DEPLOY_DIR_IMAGE}/fip/fip-stm32mp157f-ev1-optee-sdcard.bin" --ondisk mmcblk --part-type 19d5df83-11b0-457b-be2c-7559c13142a5 --fixed-size 4096K --uuid 09c54952-d5bf-45af-acee-335303766fb3
 
 # U-BOOT env
-part u-boot-env --source empty --part-name=uboot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
+part u-boot-env --source empty --part-name=u-boot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
 
 # Bootfs
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.bootfs.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M

--- a/wic/sdcard-stm32mp157f-ev1-optee-vendorfs-example.wks.in
+++ b/wic/sdcard-stm32mp157f-ev1-optee-vendorfs-example.wks.in
@@ -25,7 +25,7 @@ part fip-a   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip
 part fip-b   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip-b --sourceparams="file=${DEPLOY_DIR_IMAGE}/fip/fip-stm32mp157f-ev1-optee-sdcard.bin" --ondisk mmcblk --part-type 19d5df83-11b0-457b-be2c-7559c13142a5 --fixed-size 4096K --uuid 09c54952-d5bf-45af-acee-335303766fb3
 
 # U-BOOT env
-part u-boot-env --source empty --part-name=uboot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
+part u-boot-env --source empty --part-name=u-boot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
 
 # Bootfs
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.bootfs.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M

--- a/wic/sdcard-stm32mp157f-ev1-opteemin-example.wks.in
+++ b/wic/sdcard-stm32mp157f-ev1-opteemin-example.wks.in
@@ -25,12 +25,12 @@ part fip-a   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip
 part fip-b   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip-b --sourceparams="file=${DEPLOY_DIR_IMAGE}/fip/fip-stm32mp157f-ev1-opteemin-sdcard.bin" --ondisk mmcblk --part-type 19d5df83-11b0-457b-be2c-7559c13142a5 --fixed-size 4096K --uuid 09c54952-d5bf-45af-acee-335303766fb3
 
 # U-BOOT env
-part u-boot-env --source empty --part-name=uboot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
+part u-boot-env --source empty --part-name=u-boot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
 
 # Bootfs
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.bootfs.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M
 # Rootfs
-userfspart / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --extra-space 512M --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
+part / --source rootfs --ondisk mmcblk --fstype=ext4 --label rootfs --extra-space 512M --uuid e91c4e10-16e6-4c0e-bd0e-77becf4a3582
 # Userfs
 part userfs --source rawcopy --sourceparams="file=st-image-userfs-${DISTRO}-${MACHINE}.userfs.ext4" --ondisk mmcblk --fstype=ext4 --label userfs --fixed-size 256M
 

--- a/wic/sdcard-stm32mp157f-ev1-opteemin-vendorfs-example.wks.in
+++ b/wic/sdcard-stm32mp157f-ev1-opteemin-vendorfs-example.wks.in
@@ -25,7 +25,7 @@ part fip-a   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip
 part fip-b   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip-b --sourceparams="file=${DEPLOY_DIR_IMAGE}/fip/fip-stm32mp157f-ev1-opteemin-sdcard.bin" --ondisk mmcblk --part-type 19d5df83-11b0-457b-be2c-7559c13142a5 --fixed-size 4096K --uuid 09c54952-d5bf-45af-acee-335303766fb3
 
 # U-BOOT env
-part u-boot-env --source empty --part-name=uboot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
+part u-boot-env --source empty --part-name=u-boot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
 
 # Bootfs
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.bootfs.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M

--- a/wic/sdcard-stm32mp215f-dk-optee-example.wks.in
+++ b/wic/sdcard-stm32mp215f-dk-optee-example.wks.in
@@ -25,7 +25,7 @@ part fip-a   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip
 part fip-b   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip-b --sourceparams="file=${DEPLOY_DIR_IMAGE}/fip/fip-stm32mp215f-ev1-optee-sdcard.bin" --ondisk mmcblk --part-type 19d5df83-11b0-457b-be2c-7559c13142a5 --fixed-size 4096K --uuid 09c54952-d5bf-45af-acee-335303766fb3
 
 # U-BOOT env
-part u-boot-env --source empty --part-name=uboot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
+part u-boot-env --source empty --part-name=u-boot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
 
 # Bootfs
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.bootfs.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M

--- a/wic/sdcard-stm32mp215f-dk-optee-vendorfs-example.wks.in
+++ b/wic/sdcard-stm32mp215f-dk-optee-vendorfs-example.wks.in
@@ -25,7 +25,7 @@ part fip-a   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip
 part fip-b   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip-b --sourceparams="file=${DEPLOY_DIR_IMAGE}/fip/fip-stm32mp215f-ev1-optee-sdcard.bin" --ondisk mmcblk --part-type 19d5df83-11b0-457b-be2c-7559c13142a5 --fixed-size 4096K --uuid 09c54952-d5bf-45af-acee-335303766fb3
 
 # U-BOOT env
-part u-boot-env --source empty --part-name=uboot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
+part u-boot-env --source empty --part-name=u-boot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
 
 # Bootfs
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.bootfs.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M

--- a/wic/sdcard-stm32mp235f-dk-optee-example.wks.in
+++ b/wic/sdcard-stm32mp235f-dk-optee-example.wks.in
@@ -25,7 +25,7 @@ part fip-a   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip
 part fip-b   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip-b --sourceparams="file=${DEPLOY_DIR_IMAGE}/fip/fip-stm32mp235f-ev1-optee-sdcard.bin" --ondisk mmcblk --part-type 19d5df83-11b0-457b-be2c-7559c13142a5 --fixed-size 4096K --uuid 09c54952-d5bf-45af-acee-335303766fb3
 
 # U-BOOT env
-part u-boot-env --source empty --part-name=uboot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
+part u-boot-env --source empty --part-name=u-boot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
 
 # Bootfs
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.bootfs.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M

--- a/wic/sdcard-stm32mp235f-dk-optee-vendorfs-example.wks.in
+++ b/wic/sdcard-stm32mp235f-dk-optee-vendorfs-example.wks.in
@@ -25,7 +25,7 @@ part fip-a   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip
 part fip-b   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip-b --sourceparams="file=${DEPLOY_DIR_IMAGE}/fip/fip-stm32mp235f-ev1-optee-sdcard.bin" --ondisk mmcblk --part-type 19d5df83-11b0-457b-be2c-7559c13142a5 --fixed-size 4096K --uuid 09c54952-d5bf-45af-acee-335303766fb3
 
 # U-BOOT env
-part u-boot-env --source empty --part-name=uboot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
+part u-boot-env --source empty --part-name=u-boot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
 
 # Bootfs
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.bootfs.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M

--- a/wic/sdcard-stm32mp257f-dk-optee-example.wks.in
+++ b/wic/sdcard-stm32mp257f-dk-optee-example.wks.in
@@ -25,7 +25,7 @@ part fip-a   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip
 part fip-b   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip-b --sourceparams="file=${DEPLOY_DIR_IMAGE}/fip/fip-stm32mp257f-dk-optee-sdcard.bin" --ondisk mmcblk --part-type 19d5df83-11b0-457b-be2c-7559c13142a5 --fixed-size 4096K --uuid 09c54952-d5bf-45af-acee-335303766fb3
 
 # U-BOOT env
-part u-boot-env --source empty --part-name=uboot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
+part u-boot-env --source empty --part-name=u-boot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
 
 # Bootfs
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.bootfs.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M

--- a/wic/sdcard-stm32mp257f-dk-optee-vendorfs-example.wks.in
+++ b/wic/sdcard-stm32mp257f-dk-optee-vendorfs-example.wks.in
@@ -25,7 +25,7 @@ part fip-a   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip
 part fip-b   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip-b --sourceparams="file=${DEPLOY_DIR_IMAGE}/fip/fip-stm32mp257f-dk-optee-sdcard.bin" --ondisk mmcblk --part-type 19d5df83-11b0-457b-be2c-7559c13142a5 --fixed-size 4096K --uuid 09c54952-d5bf-45af-acee-335303766fb3
 
 # U-BOOT env
-part u-boot-env --source empty --part-name=uboot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
+part u-boot-env --source empty --part-name=u-boot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
 
 # Bootfs
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.bootfs.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M

--- a/wic/sdcard-stm32mp257f-ev1-optee-example.wks.in
+++ b/wic/sdcard-stm32mp257f-ev1-optee-example.wks.in
@@ -25,7 +25,7 @@ part fip-a   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip
 part fip-b   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip-b --sourceparams="file=${DEPLOY_DIR_IMAGE}/fip/fip-stm32mp257f-ev1-optee-sdcard.bin" --ondisk mmcblk --part-type 19d5df83-11b0-457b-be2c-7559c13142a5 --fixed-size 4096K --uuid 09c54952-d5bf-45af-acee-335303766fb3
 
 # U-BOOT env
-part u-boot-env --source empty --part-name=uboot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
+part u-boot-env --source empty --part-name=u-boot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
 
 # Bootfs
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.bootfs.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M

--- a/wic/sdcard-stm32mp257f-ev1-optee-vendorfs-example.wks.in
+++ b/wic/sdcard-stm32mp257f-ev1-optee-vendorfs-example.wks.in
@@ -25,7 +25,7 @@ part fip-a   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip
 part fip-b   --source rawcopy --fstype=ext4 --fsoptions "noauto" --part-name=fip-b --sourceparams="file=${DEPLOY_DIR_IMAGE}/fip/fip-stm32mp257f-ev1-optee-sdcard.bin" --ondisk mmcblk --part-type 19d5df83-11b0-457b-be2c-7559c13142a5 --fixed-size 4096K --uuid 09c54952-d5bf-45af-acee-335303766fb3
 
 # U-BOOT env
-part u-boot-env --source empty --part-name=uboot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
+part u-boot-env --source empty --part-name=u-boot-env --ondisk mmcblk --part-type 0x8301 --fixed-size 512K
 
 # Bootfs
 part bootfs --source rawcopy --sourceparams="file=st-image-bootfs-${DISTRO}-${MACHINE}.bootfs.ext4" --ondisk mmcblk --fstype=ext4 --label bootfs --active --fixed-size 64M


### PR DESCRIPTION
U-boot is unable to use the partition unless it's named correctly. Also fix typo in one of wks files where 'userfspart' caused it to fail.