### PR TITLE
u-boot-stm32mp: Fix FIT signing process

### DIFF
--- a/recipes-bsp/u-boot/u-boot-stm32mp.inc
+++ b/recipes-bsp/u-boot/u-boot-stm32mp.inc
@@ -209,24 +209,28 @@ export_binaries() {
                                 if [ "${UBOOT_SIGN_ENABLE}" = "1" ] && [ "${fit_uboot_sign_deploy}" = "1" ]; then
                                     # Prepare original binary for signature
                                     cp -f ${B}/${config}/u-boot-${devicetree}-${type_suffix}.${binarysuffix} ${dest}/u-boot-${devicetree}-${type_suffix}-without-signature.${binarysuffix}
-                                    # Sign dummy image images in order to add the image signing keys to our dtb
-                                    ${UBOOT_MKIMAGE_SIGN} \
-                                            ${@'-D "${UBOOT_MKIMAGE_DTCOPTS}"' if len('${UBOOT_MKIMAGE_DTCOPTS}') else ''} \
-                                            -f auto \
-                                            -k "${UBOOT_SIGN_KEYDIR}" \
-                                            -o "${FIT_HASH_ALG},${FIT_SIGN_ALG}" \
-                                            -g "${UBOOT_SIGN_IMG_KEYNAME}" \
-                                            -K "${B}/${config}/u-boot-${devicetree}-${type_suffix}.${binarysuffix}" \
-                                            -d /dev/null \
-                                            ${UBOOT_MKIMAGE_SIGN_ARGS} \
-                                            -r ${B}/${config}/unused.itb
+
+                                    if [ "${FIT_SIGN_INDIVIDUAL}" = "1" ]; then
+                                        # Sign dummy image images in order to add the image signing keys to our dtb
+                                        ${UBOOT_MKIMAGE_SIGN} \
+                                                ${@'-D "${UBOOT_MKIMAGE_DTCOPTS}"' if len('${UBOOT_MKIMAGE_DTCOPTS}') else ''} \
+                                                -f auto \
+                                                -k "${UBOOT_SIGN_KEYDIR}" \
+                                                -o "${FIT_HASH_ALG},${FIT_SIGN_ALG}" \
+                                                -g "${UBOOT_SIGN_IMG_KEYNAME}" \
+                                                -K "${B}/${config}/u-boot-${devicetree}-${type_suffix}.${binarysuffix}" \
+                                                -d /dev/null \
+                                                ${UBOOT_MKIMAGE_SIGN_ARGS} \
+                                                -r ${B}/${config}/unused.itb
+                                    fi
+
                                     # Sign dummy image configurations in order to add the configuration signing keys to our dtb
                                     ${UBOOT_MKIMAGE_SIGN} \
                                             ${@'-D "${UBOOT_MKIMAGE_DTCOPTS}"' if len('${UBOOT_MKIMAGE_DTCOPTS}') else ''} \
                                             -f auto-conf \
                                             -k "${UBOOT_SIGN_KEYDIR}" \
                                             -o "${FIT_HASH_ALG},${FIT_SIGN_ALG}" \
-                                            -g "${UBOOT_SIGN_IMG_KEYNAME}" \
+                                            -g "${UBOOT_SIGN_KEYNAME}" \
                                             -K "${B}/${config}/u-boot-${devicetree}-${type_suffix}.${binarysuffix}" \
                                             -d /dev/null \
                                             ${UBOOT_MKIMAGE_SIGN_ARGS} \


### PR DESCRIPTION
u-boot-stm32mp resigns FIT configuration during do_deploy.

The resiging process itself is not the issue, but the following:

- it uses the image keyname for both images and configuration nodes, this will break the verification process at boot time.
- it always signs the images node and Yocto sees that as optional using the FIT_SIGN_INDIVIDUAL variable

This patch fixes both issues.