### PR TITLE
KERNEL: workaround Yocto scarth limitations on bundled 'fitImage'

### DIFF
--- a/recipes-kernel/linux/linux-stm32mp.inc
+++ b/recipes-kernel/linux/linux-stm32mp.inc
@@ -133,6 +133,11 @@ correct_buildpaths() {
     done
 }
 do_install:append() {
+    # Workaround fitImage build limitations in Yocto scarthgap
+    if [ "${KERNEL_IMAGETYPE}" = 'fitImage' ] && [ ! -e ${KERNEL_OUTPUT_DIR}/${KERNEL_IMAGETYPE} ]; then
+        ln -sf ${KERNEL_IMAGETYPE}-none ${KERNEL_OUTPUT_DIR}/${KERNEL_IMAGETYPE}
+    fi
+
     # Install KERNEL_IMAGETYPE for kernel-imagebootfs package
     install -m 0644 ${KERNEL_OUTPUT_DIR}/${KERNEL_IMAGETYPE} ${D}/${KERNEL_IMAGEDEST}
 


### PR DESCRIPTION
If building with 'INITRAMFS_IMAGE = "...-image-..."'
and 'INITRAMFS_IMAGE_BUNDLE = "1"' enabled for initramfs bundle,
the installation of 'KERNEL_IMAGETYPE' as 'fitImage' fails
because of Yocto scarthgap handlings of 'fitImage-{none,bundle}'
built by different tasks under both do_install and do_deploy

This patch resolves the clean build behaviour, doing the same
as a rebuild, but bundle images are not yet respected here.

Either Yocto master 'kernel-fit-image.bbclass' is to be used,
or a clean solution without breaking the 'openembbeded-core' sources