### PR TITLE
KERNEL: add MMC aliases on stm32mp257f-ev1

### DIFF
--- a/recipes-kernel/linux/linux-stm32mp/6.6/6.6.129/0002-arm64-dts-st-add-MMC-aliases-on-stm32mp257f-ev1.patch
+++ b/recipes-kernel/linux/linux-stm32mp/6.6/6.6.129/0002-arm64-dts-st-add-MMC-aliases-on-stm32mp257f-ev1.patch
@@ -1,0 +1,30 @@
+From 84f11e135dd2a723206caf82116db49c040f9c55 Mon Sep 17 00:00:00 2001
+From: Dario Binacchi <dario.binacchi@amarulasolutions.com>
+Date: Mon, 27 Apr 2026 08:39:01 +0200
+Subject: [PATCH] arm64: dts: st: add MMC aliases on stm32mp257f-ev1
+
+Add MMC aliases to ensure that the /dev/mmcblk IDs won't change depending
+on the probe order of the MMC drivers.
+
+Signed-off-by: Dario Binacchi <dario.binacchi@amarulasolutions.com>
+Upstream-Status: Pending [specific to ST boards]
+---
+ arch/arm64/boot/dts/st/stm32mp257f-ev1.dts | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/st/stm32mp257f-ev1.dts b/arch/arm64/boot/dts/st/stm32mp257f-ev1.dts
+index bafe74a860a7..8fc0859940b0 100644
+--- a/arch/arm64/boot/dts/st/stm32mp257f-ev1.dts
++++ b/arch/arm64/boot/dts/st/stm32mp257f-ev1.dts
+@@ -23,6 +23,8 @@ / {
+ 	aliases {
+ 		ethernet0 = &eth2;
+ 		ethernet1 = &eth1;
++		mmc0 = &sdmmc1;
++		mmc1 = &sdmmc2;
+ 		serial0 = &usart2;
+ 		serial1 = &usart6;
+ 		serial2 = &lpuart1;
+-- 
+2.43.0
+

--- a/recipes-kernel/linux/linux-stm32mp_6.6.bb
+++ b/recipes-kernel/linux/linux-stm32mp_6.6.bb
@@ -20,6 +20,7 @@ SRC_URI[kernel.sha256sum] = "caa08f0122224fbbfab177e2a37cc2a94a0046bd2e7e87f03f8
 
 SRC_URI += " \
     file://${LINUX_VERSION}/${LINUX_VERSION}${LINUX_SUBVERSION}/0001-v6.6-stm32mp-r3.1.patch \
+    file://${LINUX_VERSION}/${LINUX_VERSION}${LINUX_SUBVERSION}/0002-arm64-dts-st-add-MMC-aliases-on-stm32mp257f-ev1.patch \
     "
 
 LINUX_TARGET = "stm32mp"


### PR DESCRIPTION
Add MMC aliases to ensure that the /dev/mmcblk IDs won't change depending on the probe order of the MMC drivers.

Add Linux kernel patch related to PR:
https://github.com/STMicroelectronics/linux/pull/35