### PR TITLE
BUSYBOX: ifplug does not read args from ifplugd.conf

### DIFF
--- a/recipes-core/busybox/busybox/ifplugd.conf
+++ b/recipes-core/busybox/busybox/ifplugd.conf
@@ -1,2 +1,0 @@
-INTERFACES= "eth0"
-ARGS="-fwI -u0 -d10"

--- a/recipes-core/busybox/busybox/ifplugd.sh
+++ b/recipes-core/busybox/busybox/ifplugd.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
 
 if [ -e /usr/sbin/ifplugd ]; then
-    /usr/sbin/ifplugd
+    /usr/sbin/ifplugd -I -u0 -d10
 fi

--- a/recipes-core/busybox/busybox_%.bbappend
+++ b/recipes-core/busybox/busybox_%.bbappend
@@ -5,7 +5,6 @@ PACKAGE_ARCH:stm32mpcommon = "${MACHINE_ARCH}"
 SRC_URI:append:stm32mpcommon = " \
        file://busybox-stm32mp.cfg \
        file://0001-miscutils-watchdog-Add-gettimeleft.patch \
-       file://ifplugd.conf \
        file://ifplugd.action \
        file://ifplugd.sh \
        "
@@ -19,7 +18,6 @@ do_install:append:stm32mpcommon () {
             install -d ${D}${sysconfdir}/ifplugd
             install -m 755 ${WORKDIR}/ifplugd.sh ${D}${sysconfdir}/init.d/ifplugd.sh
             update-rc.d -r ${D} ifplugd.sh start 99 2 3 4 5 .
-            install -m 755 ${WORKDIR}/ifplugd.conf ${D}${sysconfdir}/ifplugd/ifplugd.conf
             install -m 755 ${WORKDIR}/ifplugd.action ${D}${sysconfdir}/ifplugd/ifplugd.action
         fi
     fi


### PR DESCRIPTION
Hi there!

We observed an issue that happens when:
 - this default busybox/ifplugd recipe is used
 - no systemd (we used sysvinit)
 - the ethernet iface gets assigned two ip addresses (e.g. one static + one dhcp)
 - the ethernet cable was plugged but then gets unplugged for more than 10 seconds

In this case the `ifplugd.action` fails with `exit 1` and the ifplugd service is terminated:

```
[ 1077.436072] stm32-dwmac 5800a000.ethernet eth0: Link is Up - 100Mbps/Full - flow control off
ifplugd(eth0): link is up
[ 1079.514909] stm32-dwmac 5800a000.ethernet eth0: Link is Down
ifplugd(eth0): link is down
ifplugd(eth0): executing '/etc/ifplugd/ifplugd.action eth0 down'
ifplugd down
ip: can't send flush request: Cannot assign requested address
ifplugd(eth0): exit code: 1
ifplugd(eth0): exiting
```

This results in a dead eth0 port. The link is not brought up. Only a manual ifup eth0 resolves the issue.

The root cause seems to be that the busybox version of ifplugd does not read the supplied `ifplugd.conf`. Therefore the `-I` that makes it ignore failures of the `ifplugd.action` script is not enabled.

I've removed the superfluous config file and rolled the relevant arguments (busybox does not support -f and -w) into the start script. Note that I have no idea how this affects systemd enabled systems. But given the _if systemd=0_ check then I conclude that this is anyway only used for non-systemd.

Let me know if anything else shall be changed or tested more in-depth.
I'm happy to make any required changes.

Cheers, Nik